### PR TITLE
fix: resolve CSpell warnings in 044-mcts-foundation/research.md

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -9,7 +9,13 @@
         "bfoxt",
         "brandon",
         "gisting",
-        "markdownlint"
+        "markdownlint",
+        "MCTS",
+        "dtype",
+        "Zobrist",
+        "backpropagation",
+        "pydantic",
+        "isclose"
     ],
     "ignorePaths": [
         "node_modules",


### PR DESCRIPTION
## Summary

Adds 6 domain-specific technical terms to `cspell.json` to resolve all **10 CSpell warnings** reported in the [Spell Check CI job](https://github.com/vindicta-platform/specs/actions/runs/22554563877/job/65329687952?pr=51).

## Warnings Fixed

All warnings originated from `044-mcts-foundation/research.md`:

| Word | Context |
|------|---------|
| `MCTS` | Monte Carlo Tree Search — the core algorithm of FEAT-044 |
| `dtype` | NumPy data type specifier (`np.dtype`) |
| `Zobrist` | Zobrist hashing algorithm for transposition tables |
| `backpropagation` | Standard MCTS tree traversal phase |
| `pydantic` | Python data validation library (used in config models) |
| `isclose` | Python `math.isclose()` function |

## Changes

- **`cspell.json`**: Added `MCTS`, `dtype`, `Zobrist`, `backpropagation`, `pydantic`, `isclose` to the `words` list.

These are all well-established technical terms that will appear repeatedly across specs. Adding them to the project dictionary prevents false-positive warnings without disabling spell checking.