### PR TITLE
fix: accept '# Feature Specification' header in spec-validator

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -94,8 +94,9 @@ jobs:
             fi
             
             # Basic content structure check in spec.md
-            if ! grep -q "^# Summary" "$DIR/spec.md"; then
-              echo "::error file=$DIR/spec.md::spec.md must contain a '# Summary' header"
+            # Accept either '# Summary' or '# Feature Specification:' as valid top-level headers
+            if ! grep -qE "^# (Summary|Feature Specification:)" "$DIR/spec.md"; then
+              echo "::error file=$DIR/spec.md::spec.md must contain a '# Summary' or '# Feature Specification:' header"
               exit 1
             fi
             


### PR DESCRIPTION
The spec files use `# Feature Specification: <name>` as their top-level header, not `# Summary`. This causes the spec-validator job to fail for all spec PRs.

Updated the grep pattern to accept either `# Summary` or `# Feature Specification:` as valid top-level headers.