### PR TITLE
fix: address 10 issues from main branch review

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,53 +1,26 @@
-# default markdownlint rules configuration
+# Markdownlint configuration for Vindicta Platform Specs
 default: true
 
-# Exclude line length restrictions (MD013), many auto-generated files have very long lines
+# Exclude line length restrictions (MD013) — spec content is often dense
 MD013: false
 
-# Exclude bare URLs (MD034)
+# Exclude bare URLs (MD034) — specs reference raw URLs in edge case descriptions
 MD034: false
 
-# Exclude first line must be heading (MD041), we often have comments or frontmatter
+# Exclude first line must be heading (MD041) — some files have frontmatter or comments
 MD041: false
 
-# Exclude blanks around headings (MD022), sometimes omitted in checklists
-MD022: false
-
-# Exclude blanks around lists (MD032)
-MD032: false
-
-# Exclude ordered list item prefix (MD029), often people use 1. 2. 3. or 1. 1. 1.
+# Exclude ordered list item prefix (MD029) — allow both sequential and all-ones style
 MD029: false
 
-# Exclude no trailing spaces (MD009), too aggressive for simple edits
-MD009: false
-
-# Exclude inconsistent indentation for list items (MD005)
-MD005: false
-
-# Exclude inline HTML (MD033)
+# Exclude inline HTML (MD033) — templates use HTML comments for instructions
 MD033: false
 
-# Exclude hard tabs (MD010), repomix output uses them
-MD010: false
-
-# Exclude blanks around fences (MD031), repomix output misses these
-MD031: false
-
-# Exclude fenced code block language specification (MD040), repomix output misses these
-MD040: false
-
-# Exclude unordered list indentation (MD007)
-MD007: false
-
-# Exclude heading levels should only increment by one level at a time (MD001)
-MD001: false
-
-# Exclude multiple headings with the same content (MD024)
+# Exclude multiple headings with the same content (MD024) — specs reuse section names
 MD024: false
 
-# Exclude dollar signs before commands without showing output (MD014)
+# Exclude dollar signs before commands (MD014) — used in code examples
 MD014: false
 
-# Exclude single title (MD025) since Spec Validator requires `# Summary`
+# Exclude single title/H1 (MD025) — spec validator handles header validation
 MD025: false

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -1,8 +1,8 @@
 # Feature Specification: [FEATURE NAME]
 
-**Feature Branch**: `[###-feature-name]`  
-**Created**: [DATE]  
-**Status**: Draft  
+**Feature Branch**: `[###-feature-name]`
+**Created**: [DATE]
+**Status**: Draft
 **Input**: User description: "$ARGUMENTS"
 
 ## User Scenarios & Testing *(mandatory)*
@@ -11,7 +11,7 @@
   IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
   Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
   you should still have a viable MVP (Minimum Viable Product) that delivers value.
-  
+
   Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
   Think of each story as a standalone slice of functionality that can be:
   - Developed independently
@@ -85,7 +85,7 @@
 ### Functional Requirements
 
 - **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
-- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]
 - **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
 - **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
 - **FR-005**: System MUST [behavior, e.g., "log all security events"]
@@ -99,6 +99,28 @@
 
 - **[Entity 1]**: [What it represents, key attributes without implementation]
 - **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Non-Functional Requirements
+
+<!--
+  ACTION REQUIRED: Define constraints beyond functional behavior.
+  These should be measurable and technology-agnostic.
+-->
+
+### Performance
+
+- **NFR-001**: [Response time target, e.g., "API responses complete within 200ms at p95"]
+- **NFR-002**: [Throughput target, e.g., "System supports 1000 concurrent users"]
+
+### Security
+
+- **NFR-003**: [Security constraint, e.g., "All PII must be encrypted at rest and in transit"]
+- **NFR-004**: [Access control, e.g., "Role-based access with least-privilege defaults"]
+
+### Reliability
+
+- **NFR-005**: [Availability target, e.g., "99.9% uptime during business hours"]
+- **NFR-006**: [Recovery target, e.g., "Data recovery within 1 hour of failure"]
 
 ## Success Criteria *(mandatory)*
 

--- a/044-mcts-foundation/spec.md
+++ b/044-mcts-foundation/spec.md
@@ -1,47 +1,58 @@
-# Feature Specification: FEAT-044 MCTS Engine Foundation (Stockfish Equivalent)
+# Feature Specification: 044-mcts-foundation
 
-**Feature Branch**: `044-mcts-foundation`  
-**Created**: 2026-02-28  
-**Status**: Draft  
+**Feature Branch**: `044-mcts-foundation`
+**Created**: 2026-02-28
+**Status**: Draft
 **Input**: User description: "Advance the logical stockfish setup and accuracy."
-
-# Summary
-This specification defines the foundation for the Monte Carlo Tree Search (MCTS) engine, which acts as the core AI for evaluating game states and selecting optimal moves, similar to Stockfish in chess. It outlines the requirements for board state evaluation, move generation, and integration with the Entropy Buffer.
 
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Board State Evaluation (Priority: P1)
+
 As an AI developer, I want the system to take a mathematical snapshot of the current 40k board state and evaluate the win probability using Monte Carlo Tree Search (MCTS) so that we can objectively rate a player's position.
+
 **Why this priority**: Core algorithmic foundation for the entire intelligence suite.
+
 **Independent Test**: Can be tested by feeding a known "winning" board state (e.g., Turn 4, 20 VP lead, dominant board control) and verifying the engine returns a >90% win probability.
 
 **Acceptance Scenarios**:
+
 1. **Given** a structured JSON representation of the board state, **When** the MCTS engine is invoked with a depth of 3, **Then** it returns an evaluation score (e.g., +4.5) and the principal variation (best line of play).
 
+---
+
 ### User Story 2 - Move Generation Validation (Priority: P1)
+
 As the engine, I need to generate all legal moves (movement, shooting targets, charge declarations) for a given unit in a given phase, so the MCTS algorithm can branch correctly.
+
 **Why this priority**: Without legal move generation, the tree search is useless or invalid.
+
 **Independent Test**: Can be tested via unit tests that place a unit in a constrained scenario (e.g., in engagement range) and verify it only generates "Fall Back" or "Remain Stationary" and melee attack moves.
 
 **Acceptance Scenarios**:
+
 1. **Given** a unit locked in combat, **When** move generation is requested for the Movement phase, **Then** only legal actions (Fall Back, Remain Stationary) are returned.
 
 ### Edge Cases
+
 - How does the engine handle infinitely looping board states or mathematically intractable numbers of permutations? (Implement aggressive alpha-beta pruning and hard time limits per search node).
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
+
 - **FR-001**: The Engine MUST accept a standardized GameState and output an EvaluationScore.
 - **FR-002**: The Engine MUST implement Monte Carlo Tree Search with configurable depth and time constraints.
 - **FR-003**: The Engine MUST interface with the Entropy Buffer to evaluate expected values of dice rolls, rather than simulating every possible raw die outcome branching.
 
 ### Key Entities
+
 - **GameState**: The mathematical representation of the board, units, and scores.
 - **SearchNode**: A node in the MCTS tree representing a potential future state.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
+
 - **SC-001**: Engine can evaluate a mid-game state to a depth of 3 within 5 seconds on standard hardware.
 - **SC-002**: Engine move generator unit tests pass with 100% coverage against edge cases like Deep Strike and Engagement contours.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Vindicta Platform Specs
+
+Thank you for contributing! This repository uses a spec-driven methodology. All changes must follow the workflow below.
+
+## Creating a New Feature Spec
+
+1. **Create a feature branch** using the helper script:
+
+   ```powershell
+   .specify/scripts/powershell/create-new-feature.ps1 "Your feature description"
+   ```
+
+2. **Fill out `spec.md`** using the template structure:
+   - `# Feature Specification: NNN-feature-name` — top-level header
+   - `## User Scenarios & Testing` — prioritized user stories with acceptance scenarios
+   - `## Requirements` — functional requirements and key entities
+   - `## Non-Functional Requirements` — performance, security, scalability constraints
+   - `## Success Criteria` — measurable outcomes
+
+3. **Complete `checklists/requirements.md`** — validates spec quality before planning.
+
+4. **Open a Pull Request** with a conventional commit title:
+   - `docs: specification for NNN-feature-name`
+
+## PR Requirements
+
+All PRs must pass CI checks:
+
+- Markdown lint (see `.markdownlint.yaml`)
+- Spell check (add domain terms to `cspell.json`)
+- Link validation
+- Conventional PR title
+- Spec structure validation
+
+## Spec Quality Standards
+
+- **No implementation details** — specs describe *what*, not *how*
+- **Independently testable user stories** — each story should be a viable MVP slice
+- **Measurable success criteria** — technology-agnostic, quantifiable outcomes
+- **Edge cases identified** — boundary conditions and error scenarios documented
+
+## Adding Domain Terms
+
+If the spell checker flags legitimate domain terminology, add the word to `cspell.json` in the `words` array.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vindicta Platform
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Vindicta Platform — Specification Registry
+
+The single source of truth for all platform feature specifications. Each feature is defined using a BDD-first, spec-driven methodology before any implementation begins.
+
+## Repository Structure
+
+```text
+.agent/              # Agent workflows and rules
+.specify/            # Spec framework: templates, scripts, constitution
+.github/workflows/   # CI checks (markdownlint, cspell, link-check, spec-validator)
+NNN-feature-name/    # Feature specification directories (001–047)
+  spec.md            # Feature specification
+  checklists/
+    requirements.md  # Quality checklist
+```
+
+## Feature Numbering
+
+Features are numbered sequentially with a three-digit prefix (`001`–`047`). Each directory contains:
+
+| File | Purpose |
+|------|---------|
+| `spec.md` | Behavioral specification with user stories, requirements, and success criteria |
+| `checklists/requirements.md` | Quality gate checklist validated before planning |
+
+## Methodology
+
+All development follows the **BDD → TDD → Implementation** flow:
+
+1. **Specify** — Define behavioral expectations in `spec.md`
+2. **Plan** — Generate implementation design artifacts
+3. **Task** — Break the plan into dependency-ordered tasks
+4. **Implement** — Write code against failing tests
+
+See [`.specify/memory/constitution.md`](.specify/memory/constitution.md) for governance principles.
+
+## Quick Start
+
+```powershell
+# Create a new feature specification
+.specify/scripts/powershell/create-new-feature.ps1 "Your feature description"
+```
+
+## CI Checks
+
+Every pull request runs:
+
+- **Markdown Lint** — Structure and formatting
+- **Spell Check** — Domain-aware via `cspell.json`
+- **Link Checker** — Validates all URLs
+- **PR Title Lint** — Enforces conventional commits
+- **Spec Validator** — Ensures `spec.md` and `checklists/requirements.md` exist with required headers
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on creating and reviewing specifications.
+
+## License
+
+This project is licensed under the MIT License — see [LICENSE](LICENSE) for details.

--- a/cspell.json
+++ b/cspell.json
@@ -15,7 +15,20 @@
         "Zobrist",
         "backpropagation",
         "pydantic",
-        "isclose"
+        "isclose",
+        "archetype",
+        "battlescribe",
+        "scorekeeping",
+        "heatmap",
+        "heatmaps",
+        "gameplay",
+        "metagame",
+        "matchmaking",
+        "leaderboard",
+        "leaderboards",
+        "scraper",
+        "streamer",
+        "streamers"
     ],
     "ignorePaths": [
         "node_modules",


### PR DESCRIPTION
Addresses all 10 issues identified during the main branch review.

## Changes

| # | Issue | Fix |
|---|-------|-----|
| 1 | No README.md | Added repo overview with structure, methodology, quick start, and CI docs |
| 2 | No LICENSE | Added MIT License |
| 3 | No CONTRIBUTING.md | Added contributor guidelines for spec creation and PR requirements |
| 4 | 044-mcts-foundation inconsistent format | Removed duplicate `# Summary` H1, normalized header to `# Feature Specification: 044-mcts-foundation`, added proper spacing between sections |
| 5 | cspell.json missing domain terms | Added 13 words: archetype, battlescribe, scorekeeping, heatmap/s, gameplay, metagame, matchmaking, leaderboard/s, scraper, streamer/s |
| 6 | Markdownlint too permissive | Re-enabled 9 rules (MD001, MD005, MD007, MD009, MD010, MD022, MD031, MD032, MD040) that were disabled for repomix files but those are already excluded via `.markdownlintignore` |
| 7 | Stale markdownlint comment | Updated MD025 comment to reflect current spec-validator behavior |
| 8 | spec-clarify.yml stale reference | Already removed from repo; GitHub will clear the stale workflow entry automatically |
| 9 | No NFR section in spec template | Added `## Non-Functional Requirements` section with Performance, Security, and Reliability subsections |
| 10 | Default branch rename residue | Verified: no `master` references exist in `.agent/rules.md` or `.specify/scripts/`; `common.ps1` already defaults to `main` |