### PR TITLE
feat: add spec-to-issue sync workflow

### DIFF
--- a/.github/workflows/spec-to-issue-sync.yml
+++ b/.github/workflows/spec-to-issue-sync.yml
@@ -1,0 +1,128 @@
+name: Spec-to-Issue Sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '*/tasks.md'
+  workflow_dispatch:
+    inputs:
+      feature_dir:
+        description: 'Feature directory (e.g., 044-mcts-foundation)'
+        required: true
+        type: string
+
+concurrency:
+  group: spec-issues-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    name: Convert Tasks to GitHub Issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed tasks
+        id: detect
+        run: |
+          if [ -n "${{ inputs.feature_dir }}" ]; then
+            FEATURE_DIR="${{ inputs.feature_dir }}"
+          else
+            FEATURE_DIR=$(git diff --name-only HEAD~1 HEAD | grep 'tasks.md' | head -1 | xargs dirname 2>/dev/null || echo "")
+          fi
+          if [ -z "$FEATURE_DIR" ] || [ ! -f "${FEATURE_DIR}/tasks.md" ]; then
+            echo "::notice::No tasks.md changes detected"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "feature_dir=${FEATURE_DIR}" >> $GITHUB_OUTPUT
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Parse tasks and create issues
+        if: steps.detect.outputs.skip == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const featureDir = '${{ steps.detect.outputs.feature_dir }}';
+            const tasksContent = fs.readFileSync(`${featureDir}/tasks.md`, 'utf8');
+
+            // Parse task blocks: look for ## Task headers
+            const taskPattern = /^##\s+(?:Task\s+)?(\d+[\.\d]*)[:\s\-]+(.+)/gm;
+            const tasks = [];
+            let match;
+
+            while ((match = taskPattern.exec(tasksContent)) !== null) {
+              const taskNum = match[1].trim();
+              const taskTitle = match[2].trim();
+
+              // Get the body: everything between this header and the next
+              const startIdx = match.index + match[0].length;
+              const nextHeader = tasksContent.indexOf('\n## ', startIdx);
+              const body = nextHeader > -1
+                ? tasksContent.slice(startIdx, nextHeader).trim()
+                : tasksContent.slice(startIdx).trim();
+
+              tasks.push({ num: taskNum, title: taskTitle, body });
+            }
+
+            if (tasks.length === 0) {
+              core.notice('No parseable tasks found in tasks.md');
+              return;
+            }
+
+            core.info(`Found ${tasks.length} tasks to sync`);
+            let created = 0;
+            let skipped = 0;
+
+            for (const task of tasks) {
+              const issueTitle = `[${featureDir}] Task ${task.num}: ${task.title}`;
+
+              // Check if issue already exists
+              const { data: existing } = await github.rest.search.issuesAndPullRequests({
+                q: `repo:vindicta-platform/specs "${issueTitle}" is:issue`
+              });
+
+              if (existing.total_count > 0) {
+                core.info(`Skipping: ${issueTitle} (already exists)`);
+                skipped++;
+                continue;
+              }
+
+              const issueBody = [
+                `## ${task.title}`,
+                '',
+                `**Source:** \`${featureDir}/tasks.md\` — Task ${task.num}`,
+                '',
+                task.body,
+                '',
+                '---',
+                `_Auto-generated from \`${featureDir}/tasks.md\` by the Spec-to-Issue Sync workflow._`
+              ].join('\n');
+
+              await github.rest.issues.create({
+                owner: 'vindicta-platform',
+                repo: 'specs',
+                title: issueTitle,
+                body: issueBody,
+                labels: ['speckit', 'automated']
+              });
+
+              created++;
+              core.info(`Created: ${issueTitle}`);
+            }
+
+            core.summary.addRaw(`## 📋 Spec-to-Issue Sync\n\n`);
+            core.summary.addRaw(`- **Feature:** \`${featureDir}\`\n`);
+            core.summary.addRaw(`- **Created:** ${created} issues\n`);
+            core.summary.addRaw(`- **Skipped:** ${skipped} (already exist)\n`);
+            await core.summary.write();
+
+            core.notice(`Created ${created} issues, skipped ${skipped}`);


### PR DESCRIPTION
## Summary
Adds `spec-to-issue-sync.yml` — parses `tasks.md` files and creates deduplicated GitHub issues.

## What it does
- Triggers on `tasks.md` changes pushed to main or via manual dispatch
- Parses `## Task N: Title` headers and body content
- Creates labeled issues (`speckit`, `automated`) for each task
- Skips tasks that already have a matching issue (deduplication)
- Posts a summary with creation/skip counts