### PR TITLE
chore: automate speckit pipeline and remove clarify anomaly

### DIFF
--- a/.agent/rules.md
+++ b/.agent/rules.md
@@ -1,11 +1,13 @@
-# Agent Rules: GitHub Operations
+﻿# Agent Rules: GitHub Operations
 
 ## G-001: GitHub MCP Priority
 
 ### Objective
+
 Ensure consistency, efficiency, and reliability in GitHub interactions by prioritizing the use of the GitHub MCP server tools over external CLI commands (`gh`).
 
 ### Rule Definition
+
 1. **MCP First**: For any GitHub-related action (listing/searching/reading/writing issues, pull requests, files, branches, commits, or repository metadata), the agent **MUST** use the corresponding `github-mcp-server` tool.
 2. **Fallback Strategy**: The `gh` CLI (via `run_command`) should **ONLY** be used in the following scenarios:
     - The `github-mcp-server` is unavailable or fails to connect.
@@ -14,6 +16,7 @@ Ensure consistency, efficiency, and reliability in GitHub interactions by priori
 3. **Verification**: After performing a GitHub operation, verify the result using MCP tools (e.g., use `pull_request_read` after `create_pull_request`) unless the tool output itself provides sufficient confirmation.
 
 ### Motivation
+
 - **Rate Limiting**: MCP tools often have handled rate limiting or use optimized authentication.
 - **Context Awareness**: MCP tools return structured JSON data that is easier for the agent to parse than CLI string output.
 - **Reliability**: MCP tools are purpose-built for agentic interactions with the GitHub API.
@@ -21,9 +24,11 @@ Ensure consistency, efficiency, and reliability in GitHub interactions by priori
 ### Examples
 
 #### Example 1: Creating a Pull Request
+
 - **Preferred**: `mcp_github-mcp-server_create_pull_request`
 - **Fallback**: `gh pr create --title "..." --body "..."`
 
 #### Example 2: Checking Issue Status
+
 - **Preferred**: `mcp_github-mcp-server_issue_read`
 - **Fallback**: `gh issue view <number>`

--- a/.github/workflows/speckit-pipeline.yml
+++ b/.github/workflows/speckit-pipeline.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 concurrency:
-  group: speckit-pipeline-${{ github.ref }}
+  group: speckit-pipeline-${{ github.ref }}-${{ inputs.feature_dir || github.run_id }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/speckit-pipeline.yml
+++ b/.github/workflows/speckit-pipeline.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   pipeline:
-    name: Speckit Clarify → Plan → Tasks
+    name: Speckit Plan → Tasks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -70,20 +70,6 @@ jobs:
             echo "### 🏗️ Speckit Pipeline: ${FEATURE_DIR}" >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Run Clarify
-        if: steps.detect.outputs.skip == 'false'
-        run: |
-          echo "🔍 Running clarify for ${{ steps.detect.outputs.feature_dir }}..." >> $GITHUB_STEP_SUMMARY
-          if [ -f "scripts/speckit_clarify.py" ]; then
-            uv run python scripts/speckit_clarify.py --feature "${{ steps.detect.outputs.feature_dir }}" 2>&1 | tail -20 || true
-            echo "✅ Clarify complete" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "⚠️ speckit_clarify.py not found, skipping" >> $GITHUB_STEP_SUMMARY
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-
       - name: Run Plan
         if: steps.detect.outputs.skip == 'false'
         run: |
@@ -122,10 +108,9 @@ jobs:
           body: |
             ## 🏗️ Speckit Pipeline Artifacts
 
-            Auto-generated clarifications, plan, and tasks for `${{ steps.detect.outputs.feature_dir }}`.
+            Auto-generated plan and tasks for `${{ steps.detect.outputs.feature_dir }}`.
 
             **Pipeline steps:**
-            - [x] Clarify (extended_clarifications.md)
             - [x] Plan (plan.md)
             - [x] Tasks (tasks.md)
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD007": false,
+  "MD032": false
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,11 @@
 {
   "default": true,
+  "MD005": false,
   "MD007": false,
-  "MD032": false
+  "MD013": false,
+  "MD029": false,
+  "MD032": false,
+  "MD033": false,
+  "MD034": false,
+  "MD041": false
 }

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,5 +1,6 @@
-<!--
+﻿<!--
 Sync Impact Report:
+
 - Version change: 3.0.0 → 3.1.0 (MINOR)
 - List of modified sections:
   - Modular Ecosystem Registry: Updated with exact repository list from `vindicta-platform` organization analysis via GitHub MCP.
@@ -19,18 +20,23 @@ Sync Impact Report:
 ## Core Principles
 
 ### I. The Economic Prime Directive
+
 Core operations MUST run on GCP Free Tier. Agents MUST ONLY operate within the `vindicta-warhammer` project. Cost efficiency is a primary architectural constraint; variable-cost features MUST be isolated behind cost-estimation gates and Gemini-standard inference.
 
 ### II. Spec-Driven Methodology (BDD-First Mandate)
+
 No code without a Spec. All development MUST follow the **BDD → TDD → Implementation** flow. Behavioral expectations MUST be defined and confirmed failing FIRST. The `.specify` folder is the single source of truth for feature intent and requirement alignment.
 
 ### III. Tooling Adherence & Environment
+
 Strictly Windows environment (PowerShell/Batch). Mandatory use of `uv` for dependency management. Utilize project-defined CLI tools (`specify`, `just`) for all orchestration and setup. All repositories must maintain ecosystem synchronization with the Core.
 
 ### IV. Agentic Rights & Mechanical Fidelity
+
 Brevity is the enemy of nuance; chains of thought are primary deliverables. Mechanical resolutions (RNG) MUST use casino-grade CSPRNG and produce `EntropyProof`. Strict adherence to the established Source of Truth rule-sets (Engine, Economy, Oracle) is non-negotiable.
 
 ### V. Automated Quality & Stability
+
 Working models must not leave the repository in a broken state. Full unit suite must run in <60s; individual tests <1s. Mandatory `async/await` for all I/O. WIP features must be tagged with `@wip` and remain black-box oriented.
 
 ## Modular Ecosystem Registry
@@ -38,6 +44,7 @@ Working models must not leave the repository in a broken state. Full unit suite 
 The Vindicta Platform (org: `vindicta-platform`) is a distributed ecosystem of specialized repositories, each governing a specific domain. All components MUST align with the unified architecture and governance defined here.
 
 ### Specialized Repositories
+
 - **`vindicta-platform`**: The Orchestrator and mono-entry point for the platform.
 - **`vindicta-foundation`**: Core base models, underlying architecture, and constitutional framework.
 - **`vindicta-engine`**: Mechanical domain context, including Physics, Dice, and AI Core.
@@ -55,10 +62,11 @@ The Vindicta Platform (org: `vindicta-platform`) is a distributed ecosystem of s
 Prioritize precision and technical accuracy over conversational exhaustiveness. The Human User is the **Supreme Architect**. Constitutional requirements are non-negotiable. Mandatory use of directory-based memory. Standalone FAQ docs are prohibited; fix UX or documentation instead.
 
 ### VI. GitHub Operations Priority
+
 Agents MUST prioritize `github-mcp-server` for all GitHub interactions (Issues, PRs, metadata). Fallback to `gh` CLI ONLY if MCP is unavailable or lacks specific functionality. Local `git` commands remain valid for direct filesystem workspace synchronization.
 
 ## Governance
 
-The Constitution is the supreme governing document and supersedes all other practices. All PRs and reviews MUST verify compliance with these principles. Amendments require documentation and version bumps following semantic versioning. 
+The Constitution is the supreme governing document and supersedes all other practices. All PRs and reviews MUST verify compliance with these principles. Amendments require documentation and version bumps following semantic versioning.
 
 **Version**: 3.1.0 | **Ratified**: 2026-03-01 | **Last Amended**: 2026-03-01

--- a/006-rules-validation-parser/checklists/requirements.md
+++ b/006-rules-validation-parser/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 006-rules-validation-parser
+﻿# Specification Quality Checklist: 006-rules-validation-parser
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Verified rules engine requirements are abstract and user-focused.

--- a/007-battle-transcript-engine/checklists/requirements.md
+++ b/007-battle-transcript-engine/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 007-battle-transcript-engine
+﻿# Specification Quality Checklist: 007-battle-transcript-engine
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Verified streaming operations are framed contextually without strict protocol (WebSocket) demands.

--- a/008-entropy-buffer-service/checklists/requirements.md
+++ b/008-entropy-buffer-service/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 008-entropy-buffer-service
+﻿# Specification Quality Checklist: 008-entropy-buffer-service
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Abstracted gRPC mention to "secure high-throughput interface".

--- a/009-cross-domain-agents/checklists/requirements.md
+++ b/009-cross-domain-agents/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 009-cross-domain-agents
+﻿# Specification Quality Checklist: 009-cross-domain-agents
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Completed template formatting and business outcome mapping.

--- a/010-agent-persistence-layer/checklists/requirements.md
+++ b/010-agent-persistence-layer/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 010-agent-persistence-layer
+﻿# Specification Quality Checklist: 010-agent-persistence-layer
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Removed mentions of SQLite and vector store specifically - replaced with abstract persistent models.

--- a/011-agent-security-isolation/checklists/requirements.md
+++ b/011-agent-security-isolation/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 011-agent-security-isolation
+﻿# Specification Quality Checklist: 011-agent-security-isolation
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Removed Docker/chroot specifics; defined purely by "environment isolation boundaries."

--- a/012-system-audit-log/checklists/requirements.md
+++ b/012-system-audit-log/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 012-system-audit-log
+﻿# Specification Quality Checklist: 012-system-audit-log
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Removed "SHA-256" references, broadened to "cryptographic integrity checks."

--- a/013-logi-slate-ui-framework/checklists/requirements.md
+++ b/013-logi-slate-ui-framework/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 013-logi-slate-ui-framework
+﻿# Specification Quality Checklist: 013-logi-slate-ui-framework
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused SCs on rendering performance.

--- a/014-economy-management-engine/checklists/requirements.md
+++ b/014-economy-management-engine/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 014-economy-management-engine
+﻿# Specification Quality Checklist: 014-economy-management-engine
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Removed specific mentions of SQL atomic transactions; replaced with abstract "atomic distribution".

--- a/015-warscribe-core-notation/checklists/requirements.md
+++ b/015-warscribe-core-notation/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 015-warscribe-core-notation
+﻿# Specification Quality Checklist: 015-warscribe-core-notation
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on grammar definitions rather than parser implementations.

--- a/016-oracle-intelligence-suite/checklists/requirements.md
+++ b/016-oracle-intelligence-suite/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 016-oracle-intelligence-suite
+﻿# Specification Quality Checklist: 016-oracle-intelligence-suite
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Removed specifics on LLM parameters; focused on the business logic of AI analysis.

--- a/017-platform-evolution-map/checklists/requirements.md
+++ b/017-platform-evolution-map/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 017-platform-evolution-map
+﻿# Specification Quality Checklist: 017-platform-evolution-map
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked.

--- a/018-modular-ecosystem-registry/checklists/requirements.md
+++ b/018-modular-ecosystem-registry/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 018-modular-ecosystem-registry
+﻿# Specification Quality Checklist: 018-modular-ecosystem-registry
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on plugin governance constraints.

--- a/019-real-time-tournament-pairing/checklists/requirements.md
+++ b/019-real-time-tournament-pairing/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 019-real-time-tournament-pairing
+﻿# Specification Quality Checklist: 019-real-time-tournament-pairing
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Emphasized Swiss/Round-robin algorithm support requirement.

--- a/020-live-stream-overlay-widget/checklists/requirements.md
+++ b/020-live-stream-overlay-widget/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 020-live-stream-overlay-widget
+﻿# Specification Quality Checklist: 020-live-stream-overlay-widget
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Removed WebSocket/OBS specific implementation details, focusing on "real-time broadcast interface".

--- a/021-team-club-management/checklists/requirements.md
+++ b/021-team-club-management/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 021-team-club-management
+﻿# Specification Quality Checklist: 021-team-club-management
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Verified agnostic management logic.

--- a/022-voice-to-text-battle-logging/checklists/requirements.md
+++ b/022-voice-to-text-battle-logging/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 022-voice-to-text-battle-logging
+﻿# Specification Quality Checklist: 022-voice-to-text-battle-logging
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Abstracted the speech-to-intent logic; focused on the business outcome of "hands-free logging".

--- a/023-mobile-companion-app/checklists/requirements.md
+++ b/023-mobile-companion-app/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 023-mobile-companion-app
+﻿# Specification Quality Checklist: 023-mobile-companion-app
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "low footprint" and "always-on availability" outcomes.

--- a/024-hardware-dice-tower-integration/checklists/requirements.md
+++ b/024-hardware-dice-tower-integration/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 024-hardware-dice-tower-integration
+﻿# Specification Quality Checklist: 024-hardware-dice-tower-integration
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "physical-to-digital bridge" requirements.

--- a/025-ar-table-overlay/checklists/requirements.md
+++ b/025-ar-table-overlay/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 025-ar-table-overlay
+﻿# Specification Quality Checklist: 025-ar-table-overlay
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "visualizing the invisible" outcome.

--- a/026-voice-activated-scorekeeping/checklists/requirements.md
+++ b/026-voice-activated-scorekeeping/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 026-voice-activated-scorekeeping
+﻿# Specification Quality Checklist: 026-voice-activated-scorekeeping
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "intent resolution" outcomes.

--- a/027-visual-army-painter/checklists/requirements.md
+++ b/027-visual-army-painter/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 027-visual-army-painter
+﻿# Specification Quality Checklist: 027-visual-army-painter
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "digital representation/planning" outcomes.

--- a/028-coaching-marketplace/checklists/requirements.md
+++ b/028-coaching-marketplace/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 028-coaching-marketplace
+﻿# Specification Quality Checklist: 028-coaching-marketplace
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "trust and transaction" outcomes.

--- a/029-to-dashboard/checklists/requirements.md
+++ b/029-to-dashboard/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 029-to-dashboard
+﻿# Specification Quality Checklist: 029-to-dashboard
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "event-wide visibility" outcomes.

--- a/030-anti-cheat-analysis/checklists/requirements.md
+++ b/030-anti-cheat-analysis/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 030-anti-cheat-analysis
+﻿# Specification Quality Checklist: 030-anti-cheat-analysis
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "pattern recognition and probability" outcomes.

--- a/031-cross-game-inventory-sync/checklists/requirements.md
+++ b/031-cross-game-inventory-sync/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 031-cross-game-inventory-sync
+﻿# Specification Quality Checklist: 031-cross-game-inventory-sync
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "digital asset portability" outcomes.

--- a/032-campaign-map-engine/checklists/requirements.md
+++ b/032-campaign-map-engine/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 032-campaign-map-engine
+﻿# Specification Quality Checklist: 032-campaign-map-engine
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "narrative territory tracking" outcomes.

--- a/033-subscription-gifting/checklists/requirements.md
+++ b/033-subscription-gifting/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 033-subscription-gifting
+﻿# Specification Quality Checklist: 033-subscription-gifting
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "digital value transfer" outcomes.

--- a/034-battle-replay-heatmaps/checklists/requirements.md
+++ b/034-battle-replay-heatmaps/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 034-battle-replay-heatmaps
+﻿# Specification Quality Checklist: 034-battle-replay-heatmaps
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "visualizing engagement and lethality" outcomes.

--- a/035-local-store-locator/checklists/requirements.md
+++ b/035-local-store-locator/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 035-local-store-locator
+﻿# Specification Quality Checklist: 035-local-store-locator
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "finding community" outcomes.

--- a/036-twitch-extension-integration/checklists/requirements.md
+++ b/036-twitch-extension-integration/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 036-twitch-extension-integration
+﻿# Specification Quality Checklist: 036-twitch-extension-integration
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "viewer interactivity" outcomes.

--- a/037-smart-watch-score-counter/checklists/requirements.md
+++ b/037-smart-watch-score-counter/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 037-smart-watch-score-counter
+﻿# Specification Quality Checklist: 037-smart-watch-score-counter
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "wearable low-friction tracking" outcomes.

--- a/038-archetype-id/checklists/requirements.md
+++ b/038-archetype-id/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 038-archetype-id
+﻿# Specification Quality Checklist: 038-archetype-id
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Verified agnostic identification logic.

--- a/039-faq-scraper/checklists/requirements.md
+++ b/039-faq-scraper/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 039-faq-scraper
+﻿# Specification Quality Checklist: 039-faq-scraper
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "rule-update integrity" outcomes.

--- a/040-reputation-system/checklists/requirements.md
+++ b/040-reputation-system/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 040-reputation-system
+﻿# Specification Quality Checklist: 040-reputation-system
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "trust-based ecosystem" outcomes.

--- a/041-data-export/checklists/requirements.md
+++ b/041-data-export/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 041-data-export
+﻿# Specification Quality Checklist: 041-data-export
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "data sovereignty and archival" outcomes.

--- a/042-i18n-support/checklists/requirements.md
+++ b/042-i18n-support/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 042-i18n-support
+﻿# Specification Quality Checklist: 042-i18n-support
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "global rule accessibility" outcomes.

--- a/043-offline-mode/checklists/requirements.md
+++ b/043-offline-mode/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 043-offline-mode
+﻿# Specification Quality Checklist: 043-offline-mode
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "resilient tournament play" outcomes.

--- a/044-mcts-foundation/checklists/quality-assurance.md
+++ b/044-mcts-foundation/checklists/quality-assurance.md
@@ -1,33 +1,38 @@
-# Quality Assurance Checklist: MCTS Engine Foundation (FEAT-044)
+﻿# Quality Assurance Checklist: MCTS Engine Foundation (FEAT-044)
 
 **Purpose**: Validate the strictness, clarity, and completeness of the MCTS Engine requirements and contracts before and during implementation.
 **Audience**: Implementation Author & Peer/QA Reviewers
 **Focus**: Internal Engine Core + Ecosystem Integration (Strict Non-Functional Gates)
 
 ## 1. Engine Core & Data Model [Completeness & Clarity]
+
 - [x] CHK001 - Is the serialization format and boundary constraint for `GameState` perfectly unambiguous? [Clarity, Spec §FR-001] → **Resolved**: Plan defines Protobuf for wire, Pydantic internally; Research §11 defines payload limits.
 - [x] CHK002 - Are the copy-on-write immutability constraints for state transitions documented? [Completeness, Data Model] → **Resolved**: Research §6 clarifies: external immutability preserved, internal delta-based undo for performance.
 - [x] CHK003 - Is the exact mathematical hashing algorithm for transpose tables (`state_hash`) specified? [Ambiguity, Data Model] → **Resolved**: Research §4 defines Zobrist Hashing with PCG64-seeded 64-bit constants, collision handling, and hit ratio targets.
 - [x] CHK004 - Are the exact heuristics weighting ratios (VP vs Material vs Positioning) defined? [Gap, Ext. Clarifications Q21] → **Resolved**: Research §5 defines VP=0.40, Material=0.30, Control=0.30 via `HeuristicConfig(VindictaModel)`.
 
 ## 2. Memory & Performance constraints [Measurability & Coverage]
+
 - [x] CHK005 - Is the maximum allowed size of the pre-allocated fixed memory buffer explicitly quantified? [Measurability, Spec §FR-004] → **Resolved**: 512MB default, ~1.75M nodes, configurable via `MCTSEngine(memory_limit_mb=512)`.
 - [x] CHK006 - Is the behavior defining what happens *when the arena fills up* strictly specified? [Completeness, Plan Phase 0] → **Resolved**: Research §1: 90% = stop expanding + visit-based eviction; 100% = return best + `arena_exhausted` flag.
 - [x] CHK007 - Is the 5-second depth 3 evaluation constraint bound to a specific hardware baseline? [Ambiguity, Spec §SC-001] → **Resolved**: Plan defines "Standard Hardware" = 4-core ≥2.5GHz, 4GB RAM, no GPU.
 - [x] CHK008 - Are rollback or safe-failure recovery requirements defined if the execution loop panics? [Coverage, Exception Flow] → **Resolved**: Research §6 MoveStack provides undo; Research §10 references Prune & Log strategy for engine panics.
 
 ## 3. Move Generation & Edge Cases [Coverage & Consistency]
+
 - [x] CHK009 - Are all scenarios concerning the engine's reaction to "Fail States" addressed? [Coverage, Ext. Clarifications Q10] → **Resolved**: Research §10 EC table covers charge failures, Deep Strike blocks, capacity limits, etc.
 - [x] CHK010 - Is the mapping of "invalid moves" to "closest equivalent" clearly defined? [Ambiguity, Spec §Edge Cases] → **Resolved**: Research §2 defines weighted proximity function with spatial/phase/action_type components and 0.8 hard threshold.
 - [x] CHK011 - Are the requirements for infinite looping board state detection explicitly defined? [Completeness, Spec §Edge Cases] → **Resolved**: Research §4 Zobrist hashing detects repeated states via transposition tables; Research §8 adaptive time budget prevents infinite loops.
 - [x] CHK012 - Do the move generator success criteria explicitly define how many edge cases make up "100%"? [Measurability, Spec §SC-002] → **Resolved**: Research §10 enumerates 15 edge cases (EC-001 through EC-015). 100% = all 15 passing.
 
 ## 4. Integration & Extensibility [Completeness & Consistency]
+
 - [ ] CHK013 - Are the data contracts between `MCTSEngine` and `vindicta-oracle` documented for rule query fallbacks? [Gap, Ext. Clarifications Q56] → **Deferred**: Oracle integration is out of scope for MCTS foundation (Plan §Dependencies).
 - [x] CHK014 - Is the synchronization and integration mechanism with the `Entropy Buffer` defined with exact timing expectations? [Clarity, Spec §FR-003] → **Resolved**: Research §12 defines `EntropyBufferProtocol` (synchronous calls); Research §7 defines mock strategy with pre-cached fixtures.
 - [ ] CHK015 - Does the specification detail how the `MCTSResult` translates back into standard Warscribe notation? [Gap, Ext. Clarifications Q71] → **Deferred**: Warscribe encoding is handled by a separate service (per extended clarification Q71 Option B).
 - [x] CHK016 - Are the metric reporting formats (for OpenTelemetry) explicitly defined for the "Configurable trace levels"? [Completeness, Spec §FR-005] → **Resolved**: Research §3 defines `MCTSTracer` interface with OTel span attributes for NPS and cache_hit_ratio.
 
 ## 5. Security & Isolation [Non-Functional Requirements]
+
 - [x] CHK017 - Are payload sanitization limits specified to prevent infinite JSON parsing loops? [Coverage, Ext. Clarifications Q91] → **Resolved**: Research §11 defines 2MB JSON / 512KB Protobuf, max 10 nesting levels, pydantic strict validators.
 - [x] CHK018 - Are query rate limiting constraints outlined to prevent brute-forcing? [Gap, Ext. Clarifications Q95] → **Resolved**: Research §11 specifies rate limiting tied to `vindicta-economy` Gas Tank balance (no balance = 429).

--- a/044-mcts-foundation/checklists/requirements.md
+++ b/044-mcts-foundation/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: FEAT-044 MCTS Engine Foundation
+﻿# Specification Quality Checklist: FEAT-044 MCTS Engine Foundation
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-02-28
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checklist passed validation successfully based on the provided input.

--- a/044-mcts-foundation/data-model.md
+++ b/044-mcts-foundation/data-model.md
@@ -1,11 +1,13 @@
-# Phase 1: Data Model (FEAT-044)
+﻿# Phase 1: Data Model (FEAT-044)
 
 The MCTS Engine defines two primary entities: `GameState` and `SearchNode`. These will be represented using `pydantic` classes inheriting from `VindictaModel` to ensure serialization to JSON and integration compatibility across the Vindicta ecosystem.
 
 ## GameState
+
 A mathematical translation of the current 40k board.
 
 **Fields**:
+
 - `turn_number` (int): Current game turn (1-5).
 - `active_player` (str): Identifier for the player whose turn it is.
 - `unit_positions` (Dict[str, tuple[float, float, float]]): Mapping of unit IDs to their 3D coordinates.
@@ -16,9 +18,11 @@ A mathematical translation of the current 40k board.
 Modified immutably (copy-on-write) during tree expansion to ensure deterministic search.
 
 ## SearchNode
+
 A node representing a branch in the MCTS tree.
 
 **Fields**:
+
 - `id` (int): Internal index in the arena buffer.
 - `parent_id` (int | None): Pointer to parent node.
 - `children` (List[int]): Pointers to child nodes.

--- a/044-mcts-foundation/extended_clarifications.md
+++ b/044-mcts-foundation/extended_clarifications.md
@@ -8,700 +8,700 @@ For each, please provide a short answer or select an option to guide the technic
 
 1. **Encoding**: How are unit properties and locations explicitly encoded in memory (e.g., bitboards, struct arrays, entity-component)?
    - **Options**:
-    - A) Bitboards (High efficiency, requires complex bitmasking logic)
-    - B) Typed NumPy Arrays / Struct Arrays (Fast attribute access, easy vectorization)
-    - C) Pydantic/VindictaModel classes (High abstraction, slower for high-frequency tree nodes)
+   - A) Bitboards (High efficiency, requires complex bitmasking logic)
+   - B) Typed NumPy Arrays / Struct Arrays (Fast attribute access, easy vectorization)
+   - C) Pydantic/VindictaModel classes (High abstraction, slower for high-frequency tree nodes)
    - **Recommended**: Option B - NumPy arrays offer a balance of Python-native readability and near-C performance for state snapshots.
 
 2. **Hidden Information**: Is the board state passed to the MCTS fully observable, or are hidden secondary objectives obfuscated?
    - **Options**:
-    - A) Fully Observable (Standard MCTS, simpler implementation)
-    - B) Partially Observable (Information Set MCTS, handles fog-of-war/hidden cards)
-    - C) Cheating AI (AI sees all, but pretends not to)
+   - A) Fully Observable (Standard MCTS, simpler implementation)
+   - B) Partially Observable (Information Set MCTS, handles fog-of-war/hidden cards)
+   - C) Cheating AI (AI sees all, but pretends not to)
    - **Recommended**: Option A - For a foundation layer, perfect information simplifies the search; hidden info can be modeled as "expected value" branches later.
 
 3. **Serialization**: What serialization format is used for network transfer of GameStates (e.g., JSON, Protocol Buffers, FlatBuffers)?
    - **Options**:
-    - A) JSON (Human readable, high overhead)
-    - B) Protocol Buffers (Compact, fast, typed)
-    - C) FlatBuffers (Zero-copy, fastest but more complex schema management)
+   - A) JSON (Human readable, high overhead)
+   - B) Protocol Buffers (Compact, fast, typed)
+   - C) FlatBuffers (Zero-copy, fastest but more complex schema management)
    - **Recommended**: Option B - Protobuf provides the best middle ground for the `vindicta-platform` microservice mesh.
 
 4. **Terrain**: How is 3D terrain conceptually represented in the mathematical snapshot to calculate line-of-sight efficiently?
    - **Options**:
-    - A) Voxel Grid (High precision, memory intensive)
-    - B) 2D Heightmap + Obstacle Polygons (Simpler LoS math)
-    - C) Abstract Keyword Tags (e.g., "Obscuring") with simplified bounding boxes
+   - A) Voxel Grid (High precision, memory intensive)
+   - B) 2D Heightmap + Obstacle Polygons (Simpler LoS math)
+   - C) Abstract Keyword Tags (e.g., "Obscuring") with simplified bounding boxes
    - **Recommended**: Option C - Standardizing on "Obscuring" / "Cover" tags aligns with the core game engine logic rules.
 
 5. **Aura Effects**: Are aura effects computed dynamically during evaluation, or are they statically attached as state flags per unit?
    - **Options**:
-    - A) Dynamic (Computed on-demand, always accurate)
-    - B) Static Flags (Pre-calculated at start of phase/turn, faster but risk of staleness)
-    - C) Incremental (Updated only when a unit moves)
+   - A) Dynamic (Computed on-demand, always accurate)
+   - B) Static Flags (Pre-calculated at start of phase/turn, faster but risk of staleness)
+   - C) Incremental (Updated only when a unit moves)
    - **Recommended**: Option B - Statically attaching flags during a "Snapshot Refresh" phase significantly speeds up playout evaluations.
 
 ## 2. Move Generation Logic
 
 6. **Laziness**: Are child moves generated lazily (on demand per expanded node) or eagerly (all at once per state)?
    - **Options**:
-    - A) Lazy (Lower memory, slower leaf expansion)
-    - B) Eager (Faster search, higher memory usage per node)
+   - A) Lazy (Lower memory, slower leaf expansion)
+   - B) Eager (Faster search, higher memory usage per node)
    - **Recommended**: Option A - For Depth 3+, lazy expansion prevents generating thousands of unused move branches for low-probability nodes.
 
 7. **Compound Actions**: How are compound action sequences (e.g., move, then shoot, then charge) segmented into decision nodes?
    - **Options**:
-    - A) Flattened (All permutations are siblings at one depth)
-    - B) Phase-Sequential (Move node -> Shoot node -> Charge node)
-    - C) Action Bundling (Agents submit an "Entire Turn Plan" as one branch)
+   - A) Flattened (All permutations are siblings at one depth)
+   - B) Phase-Sequential (Move node -> Shoot node -> Charge node)
+   - C) Action Bundling (Agents submit an "Entire Turn Plan" as one branch)
    - **Recommended**: Option B - Multi-step sequential nodes better represent the reactive nature of stratagems and dice outcomes.
 
 8. **Measurements**: How does the generator handle continuous distances (e.g., 6" move) in a discrete search tree?
    - **Options**:
-    - A) Discretized Grid (Move 1, 2, 3... inches)
-    - B) Cardinal Directions (Fixed point navigation)
-    - C) Cluster-Based (Only generate moves to "meaningful" objective or cover zones)
+   - A) Discretized Grid (Move 1, 2, 3... inches)
+   - B) Cardinal Directions (Fixed point navigation)
+   - C) Cluster-Based (Only generate moves to "meaningful" objective or cover zones)
    - **Recommended**: Option C - Moving to "points of interest" reduces the branching factor from infinite to manageable.
 
 9. **Stratagems**: Are CP usage and reactive stratagems considered standard "moves" in the tree?
    - **Options**:
-    - A) Yes (Full decision tree including resource management)
-    - B) No (Stratagems are handled by a separate heuristic "override" layer)
-    - C) Dynamic Pruning (Only include critical CP moves like "Interrupt")
+   - A) Yes (Full decision tree including resource management)
+   - B) No (Stratagems are handled by a separate heuristic "override" layer)
+   - C) Dynamic Pruning (Only include critical CP moves like "Interrupt")
    - **Recommended**: Option C - Pruning CP usage to only high-impact actions keeps the breadth manageable.
 
 10. **Fail States**: How are "Fail" scenarios (e.g., a failed 9" charge) mapped to branch continuations?
-    - **Options**:
+   - **Options**:
       - A) Stochastic Nodes (Tree branches into "Success" and "Failure" children)
       - B) Weighted Averages (Rollout uses the Entropy Buffer's mean outcome)
       - C) Outcome Sampling (Node represents only the most likely outcome)
-    - **Recommended**: Option A - Real branches for success/failure are essential for risk-assessment logic in MCTS.
+   - **Recommended**: Option A - Real branches for success/failure are essential for risk-assessment logic in MCTS.
 
 ## 3. MCTS Node Expansion & Selection
 
 11. **UCT Formula**: What variant of the Upper Confidence Bound applied to Trees (UCT) formula will govern node selection?
-    - **Options**:
+   - **Options**:
       - A) Standard UCT1 (Exploration vs Exploitation balance)
       - B) PUCT (Predictor + UCB, used in AlphaZero)
       - C) RAVE (Rapid Action Value Estimation)
-    - **Recommended**: Option A - Start with Standard UCT1; it is robust and easiest to tune for the foundation.
+   - **Recommended**: Option A - Start with Standard UCT1; it is robust and easiest to tune for the foundation.
 
 12. **Playout Strategy**: Does the engine use random heavy rollouts or a heuristic shallow evaluation function for unvisited nodes?
-    - **Options**:
+   - **Options**:
       - A) Traditional Rollouts (Simulate game to end - slow in 40k)
       - B) Heuristic Evaluation (Assign score at terminal depth, then backpropagate)
       - C) Hybrid (Short rollout + evaluation)
-    - **Recommended**: Option B - Given the complexity of 40k, a professional heuristic score (Stockfish-style) at Depth 3 is more viable than full rollouts.
+   - **Recommended**: Option B - Given the complexity of 40k, a professional heuristic score (Stockfish-style) at Depth 3 is more viable than full rollouts.
 
 13. **Progressive Unpruning**: Will the engine implement progressive unpruning for branching factors that are initially too large?
-    - **Options**:
+   - **Options**:
       - A) Yes (Gradually add moves as visit count increases)
       - B) No (Evaluate all legal moves from the start)
-    - **Recommended**: Option A - Essential for game states with hundreds of possible shooting/movement permutations.
+   - **Recommended**: Option A - Essential for game states with hundreds of possible shooting/movement permutations.
 
 14. **Transpositions**: How are transposition tables (tracking identical board states reached via different move orders) integrated?
-    - **Options**:
+   - **Options**:
       - A) Zobrist Hashing (Industry standard for chess/Go)
       - B) State Delta Sets (Compare unit-by-unit differences)
       - C) No Transposition (Re-evaluate identical states independently)
-    - **Recommended**: Option A - Zobrist Hashing is mandatory for avoiding redundant computation in iterative deepening.
+   - **Recommended**: Option A - Zobrist Hashing is mandatory for avoiding redundant computation in iterative deepening.
 
 15. **Reward Discounting**: Is there a discount factor applied to rewards deeper in the tree to favor immediate certainty?
-    - **Options**:
+   - **Options**:
       - A) Exponential Decay (Gains far in the future are worth less)
       - B) Discrete Step Penalty (Fixed cost per turn/depth)
       - C) No Discount (Win in 5 turns is same as win in 1)
-    - **Recommended**: Option A - Prevents the AI from "shuffling" or delaying a win when an immediate advantage is available.
+   - **Recommended**: Option A - Prevents the AI from "shuffling" or delaying a win when an immediate advantage is available.
 
 ## 4. Entropy Buffer Integration
 
 16. **Expectation Strategy**: How are results derived from the Entropy Buffer (mean averages vs distribution sampling per rollout)?
-    - **Options**:
+   - **Options**:
       - A) Mean Average (Deterministic, fast, but "boring" play)
       - B) Weighted Distribution Sampling (Probabilistic, more realistic)
       - C) Percentile Pruning (Only consider 25th-75th percentile outcomes)
-    - **Recommended**: Option B - Sampling from the distribution provides the "swinginess" inherent in 40k that MCTS needs to account for.
+   - **Recommended**: Option B - Sampling from the distribution provides the "swinginess" inherent in 40k that MCTS needs to account for.
 
 17. **Re-rolls**: Are re-rolls (e.g., Command Re-roll) resolved instantly within a buffer query or treated as separate decision branches?
-    - **Options**:
+   - **Options**:
       - A) Procedural (Buffer handles re-roll math internally in one call)
       - B) Branching (A re-roll is a separate move node in the tree)
       - C) Heuristic (Add a +X% boost to the initial roll success probability)
-    - **Recommended**: Option A - Having the buffer handle re-roll math internally keeps the tree depth from exploding.
+   - **Recommended**: Option A - Having the buffer handle re-roll math internally keeps the tree depth from exploding.
 
 18. **Granularity**: What is the granularity of dice expectation requests (per single shot vs aggregate per attack sequence)?
-    - **Options**:
+   - **Options**:
       - A) Per Die (Highest precision, extreme latency)
       - B) Per Sequence (e.g., "10 shots at 3+ to hit")
       - C) Per Unit-Phase (Aggregate all attacks from one unit)
-    - **Recommended**: Option B - "Per Sequence" is the standard for efficient 40k math engines.
+   - **Recommended**: Option B - "Per Sequence" is the standard for efficient 40k math engines.
 
 19. **Mortal Wounds**: How are low-probability outlier events (e.g., rolling 6s to wound causing mortal spikes) weighted?
-    - **Options**:
+   - **Options**:
       - A) Ignored (Too rare to model)
       - B) Linear Weighting (Include in the average)
       - C) Importance Sampling (Give outliers higher weight during specific phases)
-    - **Recommended**: Option B - Linear weighting in the distribution sampling ensures they occur at the correct frequency.
+   - **Recommended**: Option B - Linear weighting in the distribution sampling ensures they occur at the correct frequency.
 
 20. **Synchronization**: Does the engine pre-fetch buffer probabilities, or query the buffer synchronously during evaluation?
-    - **Options**:
+   - **Options**:
       - A) Synchronous (Simplest, but creates compute bottlenecks)
       - B) Pre-fetch / Cache (Store common roll results in memory)
       - C) Asynchronous (Parallelize buffer calls, process branches when results return)
-    - **Recommended**: Option B - Caching the Top 500 most common dice interactions (e.g., 20 S4 shots into T4) is the best performance win.
+   - **Recommended**: Option B - Caching the Top 500 most common dice interactions (e.g., 20 S4 shots into T4) is the best performance win.
 
 ## 5. Evaluation Heuristics (Static Evaluation)
 
 21. **Scoring Weights**: What is the relative weight ratio between VP lead, Material advantage, and Positional control?
-    - **Options**:
+   - **Options**:
       - A) Material Dominant (Kill everything first)
       - B) VP Dominant (Focus strictly on objectives)
       - C) Balanced (40% VP, 30% Material, 30% Control)
-    - **Recommended**: Option C - A balanced approach prevents the "passive objective holding" and "pointless bloodlust" extremes.
+   - **Recommended**: Option C - A balanced approach prevents the "passive objective holding" and "pointless bloodlust" extremes.
 
 22. **Dynamic Overrides**: Are these heuristic weights hardcoded, or dynamically loaded via a remote config system?
-    - **Options**:
+   - **Options**:
       - A) Hardcoded (Fastest, requires re-build to change)
       - B) Remote Config / JSON (Flexible, easy to A/B test without deployment)
       - C) Agent-Defined (The calling agent passes the weights in the payload)
-    - **Recommended**: Option B - Using a remote config (as per project guidelines for `remote_config_master.md`) allows tuning without code changes.
+   - **Recommended**: Option B - Using a remote config (as per project guidelines for `remote_config_master.md`) allows tuning without code changes.
 
 23. **Objective Holding**: How is objective control evaluated if the scoring phase is not immediate?
-    - **Options**:
+   - **Options**:
       - A) Sticky Control (Unit is on it now = points eventually)
       - B) Projected Control (Who is likely to have OC on it at the end of the battle round?)
       - C) Distance Weighted (Reward proximity to objective centers)
-    - **Recommended**: Option B - Projected control after all phase nodes resolve is the most accurate for 10th Edition.
+   - **Recommended**: Option B - Projected control after all phase nodes resolve is the most accurate for 10th Edition.
 
 24. **Phase Scaling**: Does the evaluation function scale its priorities based on the current game turn (e.g., late game values VP higher)?
-    - **Options**:
+   - **Options**:
       - A) Yes (Linear scaling of VP weight over 5 turns)
       - B) No (Static evaluation throughout)
-    - **Recommended**: Option A - VP is much more valuable on Turn 5 than Turn 1, where material preservation is key.
+   - **Recommended**: Option A - VP is much more valuable on Turn 5 than Turn 1, where material preservation is key.
 
 25. **Secondary Objectives**: How are player-selected secondary objectives factored into the base heuristic score?
-    - **Options**:
+   - **Options**:
       - A) Global Heuristic (Add points for "Action" completions)
       - B) Explicit Trackers (Separate logic sub-modules per objective)
       - C) Ignored (AI only cares about Primary/Material)
-    - **Recommended**: Option B - Since secondaries are highly specific (e.g., "Behind Enemy Lines"), they require explicit sub-logic.
+   - **Recommended**: Option B - Since secondaries are highly specific (e.g., "Behind Enemy Lines"), they require explicit sub-logic.
 
 ## 6. Time Management & Search Constraints
 
 26. **Budget Distribution**: How does the engine distribute the 5-second budget across iterative deepening phases?
-    - **Options**:
+   - **Options**:
       - A) Fixed % (e.g., 20% for Depth 1, 30% for Depth 2, 50% for Depth 3)
       - B) Adaptive (Stop when time is 90% exhausted regardless of current depth progress)
       - C) Early Exit (Return best move immediately if one line is >95% win prob)
-    - **Recommended**: Option B - Adaptive time-slicing ensures we never miss the 5-second hard limit.
+   - **Recommended**: Option B - Adaptive time-slicing ensures we never miss the 5-second hard limit.
 
 27. **Hard Stops**: Is there an asynchronous emergency "hard stop" signal if the evaluation exceeds strictly allowed time?
-    - **Options**:
+   - **Options**:
       - A) Yes (Search loop checks `time.time()` every N iterations)
       - B) No (Rely on host OS/Container to kill the process)
-    - **Recommended**: Option A - Mandatory for a robust backend engine.
+   - **Recommended**: Option A - Mandatory for a robust backend engine.
 
 28. **Resumability**: Can an MCTS search tree state be paused and safely resumed across multiple network requests?
-    - **Options**:
+   - **Options**:
       - A) Yes (Store the tree in a shared Redis/Cache)
       - B) No (Engine is stateless; a new request starts a new search)
-    - **Recommended**: Option B - Statelessness is simpler to scale horizontally.
+   - **Recommended**: Option B - Statelessness is simpler to scale horizontally.
 
 29. **Time Pools**: Will the engine support variable time pools per player (e.g., blitz vs standard time controls)?
-    - **Options**:
+   - **Options**:
       - A) Yes (Engine accepts a `time_budget_ms` parameter)
       - B) No (Global 5-second limit)
-    - **Recommended**: Option A - Allows the same engine to power both "Fast Preview" and "Deep Calculation" use cases.
+   - **Recommended**: Option A - Allows the same engine to power both "Fast Preview" and "Deep Calculation" use cases.
 
 30. **Early Termination**: What happens if the absolute depth limit of 3 is fully exhausted before the 5 seconds are up?
-    - **Options**:
+   - **Options**:
       - A) Return Result (Stop and save the computation cost)
       - B) Iterative Deepening (Proceed to Depth 4+ until time runs out)
-    - C) Statistical Softening (Use remaining time to run more rollouts on current leaves)
-    - **Recommended**: Option B - If time remains, deeper search is always better for accuracy.
+   - C) Statistical Softening (Use remaining time to run more rollouts on current leaves)
+   - **Recommended**: Option B - If time remains, deeper search is always better for accuracy.
 
 ## 7. Concurrency & Parallelization
 
 31. **Threading Model**: Does the search employ Root Parallelism, Leaf Parallelism, or Tree Parallelism?
-    - **Options**:
+   - **Options**:
       - A) Root Parallelism (Run N independent trees, merge results at end - easiest)
       - B) Tree Parallelism (Multiple threads share one tree - requires locking)
       - C) Leaf Parallelism (Search is serial, but terminal evaluations are parallel)
-    - **Recommended**: Option A - Root Parallelism is the most Python-friendly (avoiding GIL issues) and scales well in containerized environments.
+   - **Recommended**: Option A - Root Parallelism is the most Python-friendly (avoiding GIL issues) and scales well in containerized environments.
 
 32. **Mutex Locks**: If using Tree Parallelism, how are node statistic updates handle concurrency (lock-free vs mutexed)?
-    - **Options**:
+   - **Options**:
       - A) Lock-free (Atomic updates using specific CPU instructions - complex in Python)
       - B) Mutexed (Standard locks on node objects)
       - C) Batch Updates (Workers accumulate stats and update the tree in a single-threaded sweep)
-    - **Recommended**: Option C - Batching updates minimizes lock contention and provides cleaner trace logs.
+   - **Recommended**: Option C - Batching updates minimizes lock contention and provides cleaner trace logs.
 
 33. **Instance Scaling**: What is the maximum target thread count per container instance?
-    - **Options**:
+   - **Options**:
       - A) Single-threaded (1 vCPU)
       - B) 4-8 Threads (Standard high-performance container)
       - C) Elastic (Scale based on available machine cores)
-    - **Recommended**: Option B - Standardizing on 4-8 threads provides predictable performance for 5-second budgets.
+   - **Recommended**: Option B - Standardizing on 4-8 threads provides predictable performance for 5-second budgets.
 
 34. **Cache Syncing**: How are transposition tables synchronized across multiple worker threads efficiently?
-    - **Options**:
+   - **Options**:
       - A) Shared Memory Hash Table (requires extreme care with Python objects)
       - B) Per-Thread Cache (No sync, higher memory usage)
       - C) Sharded Cache (Divide hash range across workers)
-    - **Recommended**: Option C - Sharding reduces collisions and works well with root parallelism.
+   - **Recommended**: Option C - Sharding reduces collisions and works well with root parallelism.
 
 35. **Determinism vs Speed**: Will thread races be permitted if it increases nodes-per-second, or is strict determinism required?
-    - **Options**:
+   - **Options**:
       - A) Strict Determinism (Repeatable results for debugging/testing)
       - B) Asynchronous Racy Updates (Accept small inaccuracies for higher throughput)
-    - **Recommended**: Option A - Determinism is a strict requirement for `vindicta-platform` to ensure audit trails and repeatable tests.
+   - **Recommended**: Option A - Determinism is a strict requirement for `vindicta-platform` to ensure audit trails and repeatable tests.
 
 ## 8. Pruning & Tree Reduction
 
 36. **Forward Pruning**: Is Forward Pruning aggressively applied to moves with historically low immediate payouts?
-    - **Options**:
+   - **Options**:
       - A) Yes (Only consider Top N most promising moves)
       - B) No (Trust UCT to naturally ignore bad branches)
-    - **Recommended**: Option A - aggressive pruning is necessary for 40k due to the high branching factor (e.g. dozens of targets for one unit).
+   - **Recommended**: Option A - aggressive pruning is necessary for 40k due to the high branching factor (e.g. dozens of targets for one unit).
 
 37. **Alpha-Beta Hybrid**: How exactly are Alpha-Beta pruning bounds integrated within an MCTS framework?
-    - **Options**:
+   - **Options**:
       - A) Fixed Bounds (Prune nodes below a hard static score)
       - B) Dynamic Windowing (Use MCTS visit counts to define search "windows")
       - C) No Hybrid (Use pure MCTS)
-    - **Recommended**: Option C - Stick to pure MCTS initially; alpha-beta hybrids are mathematically complex to integrate with UCT.
+   - **Recommended**: Option C - Stick to pure MCTS initially; alpha-beta hybrids are mathematically complex to integrate with UCT.
 
 38. **Symmetry**: Does the engine detect and eliminate obviously symmetrical board state permutations?
-    - **Options**:
+   - **Options**:
       - A) Automatic (Hash units by relative position rather than absolute ID)
       - B) Manual (Rules engine flags redundant moves)
       - C) Disabled (Accept the overhead)
-    - **Recommended**: Option C - Determining symmetry in a complex 3D 40k environment is often more expensive than just searching the Redundant node.
+   - **Recommended**: Option C - Determining symmetry in a complex 3D 40k environment is often more expensive than just searching the Redundant node.
 
 39. **Null Moves**: Are "Null Move" heuristics allowed to test for immediate localized threat detection?
-    - **Options**:
+   - **Options**:
       - A) Yes (Test if not moving still results in unit death)
       - B) No (Every unit must declare an action)
-    - **Recommended**: Option A - "What if I do nothing?" is a powerful baseline for evaluating threat levels.
+   - **Recommended**: Option A - "What if I do nothing?" is a powerful baseline for evaluating threat levels.
 
 40. **Dice Pruning**: How aggressive is the pruning on highly improbable dice combinations (e.g., failing five 2+ armor saves)?
-    - **Options**:
+   - **Options**:
       - A) Aggressive (Ignore roll outcomes with <1% probability)
       - B) Balanced (Ignore <0.1% probability)
       - C) Full (Include every possible discrete die combination)
-    - **Recommended**: Option A - Pruning extreme outliers keeps the tree representation sane and focused on realistic outcomes.
+   - **Recommended**: Option A - Pruning extreme outliers keeps the tree representation sane and focused on realistic outcomes.
 
 ## 9. Observability, Tracing, and Logging
 
 41. **Trace Format**: What industry-standard format is used for exported traces (OpenTelemetry, JSON logs)?
-    - **Options**:
+   - **Options**:
       - A) OpenTelemetry (OTLP) (Native support for Jaeger/Grafana)
       - B) Structured JSON Logs (Easy to pipe to ELK/CloudWatch)
       - C) Custom Binary (Fastest export, requires custom viewer)
-    - **Recommended**: Option A - Standardizing on OTel is mandatory for the `vindicta-foundation` observability goals.
+   - **Recommended**: Option A - Standardizing on OTel is mandatory for the `vindicta-foundation` observability goals.
 
 42. **PV Export**: Is the Final Principal Variation exported automatically to standard out or dedicated metrics stores?
-    - **Options**:
+   - **Options**:
       - A) Stdout (Simple for local dev)
       - B) Metric Store (Prometheus/InfluxDB)
       - C) API Payload (Returned in the search result object)
-    - **Recommended**: Option C - The PV is functional data; it belongs in the response payload.
+   - **Recommended**: Option C - The PV is functional data; it belongs in the response payload.
 
 43. **NPS Tracking**: How are nodes-per-second (NPS) and cache-hit metrics aggregated and visualized?
-    - **Options**:
+   - **Options**:
       - A) Prometheus Counters (Real-time monitoring)
       - B) Trace Attributes (Per-request granularity)
       - C) Console Logs (Debugging only)
-    - **Recommended**: Option B - Attaching NPS to the request trace identifies slow scenarios/board states.
+   - **Recommended**: Option B - Attaching NPS to the request trace identifies slow scenarios/board states.
 
 44. **Reproducibility**: Can developers trace and extract the exact random seed used for a specific outlier rollout?
-    - **Options**:
+   - **Options**:
       - A) Yes (Random seed is logged per request)
       - B) No (Seeds are transient)
-    - **Recommended**: Option A - Essential for fixing "hallucination" bugs where the AI makes a bizarre move.
+   - **Recommended**: Option A - Essential for fixing "hallucination" bugs where the AI makes a bizarre move.
 
 45. **Artifact Retention**: How long are full memory tree dumps (if Level 4 Trace is enabled) retained on disk?
-    - **Options**:
+   - **Options**:
       - A) 1 Hour (Local buffer)
       - B) 7 Days (Standard debug window)
       - C) Not Retained (Live stream only)
-    - **Recommended**: Option B - Seven days allows for retroactive post-mortem analysis of failed game sessions.
+   - **Recommended**: Option B - Seven days allows for retroactive post-mortem analysis of failed game sessions.
 
 ## 10. Hardware & Resource Limits
 
 46. **Hardware Acceleration**: Are neural network evaluations (if added later) explicitly targeted for CPU or GPU hardware?
-    - **Options**:
+   - **Options**:
       - A) CPU Only (Focus on vectorized AVX/SIMD instructions)
       - B) GPU Accelerated (Requires CUDA/ROCm dependencies)
       - C) NPU/Dedicated (Targeting edge AI hardware)
-    - **Recommended**: Option A - CPU-only simplifies the container deployment and is sufficient for the foundation's mathematical complexity.
+   - **Recommended**: Option A - CPU-only simplifies the container deployment and is sufficient for the foundation's mathematical complexity.
 
 47. **Memory Limits**: What is the default hard RAM limit for the Engine container (e.g., 1GB, 4GB)?
-    - **Options**:
+   - **Options**:
       - A) 1GB (Lightweight, high density)
       - B) 4GB (Balanced for large MCTS trees)
       - C) 16GB+ (For professional tournament-grade depth)
-    - **Recommended**: Option B - 4GB provides enough space for a massive transposition table and arena allocator.
+   - **Recommended**: Option B - 4GB provides enough space for a massive transposition table and arena allocator.
 
 48. **Eviction Strategy**: How is cache eviction managed when memory constraints are reached (LRU vs Depth-based)?
-    - **Options**:
+   - **Options**:
       - A) LRU (Least Recently Used - standard)
       - B) Depth-based (Protect nodes closer to the root)
       - C) Visit-based (Keep nodes with the most statistical weight)
-    - **Recommended**: Option C - In MCTS, the nodes with the most visits are the most valuable to retain.
+   - **Recommended**: Option C - In MCTS, the nodes with the most visits are the most valuable to retain.
 
 49. **Vectorization**: Does the engine rely on strict SIMD/Vectorization instruction sets for bit computations?
-    - **Options**:
+   - **Options**:
       - A) Explicit (Use NumPy/PyTorch internals for vector math)
       - B) Auto-vectorized (Trust Python interpreter/compiler)
       - C) None (Pure Python objects)
-    - **Recommended**: Option A - Mandatory for meeting the 5-second depth 3 goal in Python.
+   - **Recommended**: Option A - Mandatory for meeting the 5-second depth 3 goal in Python.
 
 50. **CPU Arch**: Will the infrastructure predominantly deploy on ARM64 (AWS Graviton/M-series) or standard x86_64?
-    - **Options**:
+   - **Options**:
       - A) ARM64 (Cost effective, modern)
       - B) x86_64 (Broad compatibility)
       - C) Multi-arch (Support both)
-    - **Recommended**: Option C - The codebase should be multi-arch, but ARM64 is the preferred production target for cost.
+   - **Recommended**: Option C - The codebase should be multi-arch, but ARM64 is the preferred production target for cost.
 
 ## 11. Integration with `vindicta-engine` (Core Logic)
 
 51. **Logic Duplication**: Does MCTS duplicate `vindicta-engine`'s rules internally for speed, or call the module directly?
-    - **Options**:
+   - **Options**:
       - A) Call Directly (Maintainable, slower)
       - B) Compiled Subset (Duplicate critical path logic in Cython/Numba for speed)
       - C) Logic Mapping (MCTS uses a simplified proxy of the full engine)
-    - **Recommended**: Option B - Re-implementing the core "Move/Hit/Wound" loop in a high-performance subset is essential for Stockfish-level speed.
+   - **Recommended**: Option B - Re-implementing the core "Move/Hit/Wound" loop in a high-performance subset is essential for Stockfish-level speed.
 
 52. **State Mutability**: Is `vindicta-engine` structurally stateless enough to support concurrent node expansion without cloning entire domains?
-    - **Options**:
+   - **Options**:
       - A) Full Clone (Copy entire GameState object - slow)
       - B) Copy-on-Write (Only clone modified units)
       - C) Delta-based (Apply moves and then "Undo" them to return to parent state)
-    - **Recommended**: Option C - "Undo" logic (Rollback) is the preferred industry standard for high-performance search engines.
+   - **Recommended**: Option C - "Undo" logic (Rollback) is the preferred industry standard for high-performance search engines.
 
 53. **Rules Erratas**: How are mid-season rule erratas dynamically injected into the active search heuristics?
-    - **Options**:
+   - **Options**:
       - A) Factory Pattern (Inject new logic classes)
       - B) Parameterized Constants (Change math weights via config)
       - C) Code Deployment (Hard update the module)
-    - **Recommended**: Option B - Most erratas (e.g., points changes, AP caps) can be handled as weights in the evaluation function.
+   - **Recommended**: Option B - Most erratas (e.g., points changes, AP caps) can be handled as weights in the evaluation function.
 
 54. **Panic Handling**: What happens to a tree branch if `vindicta-engine` unexpectedly panics or throws an exception during rollout?
-    - **Options**:
+   - **Options**:
       - A) Prune & Log (Discard the branch, mark moves as invalid)
       - B) Hard Fail (Kill the search session)
       - C) Retry (Re-initialize state and try same move again)
-    - **Recommended**: Option A - Robust systems should prune the segment and continue searching healthy branches.
+   - **Recommended**: Option A - Robust systems should prune the segment and continue searching healthy branches.
 
 55. **Versioning Cycle**: How tightly coupled is the MCTS release cycle to `vindicta-engine` version updates?
-    - **Options**:
+   - **Options**:
       - A) Locked (Must match major.minor version)
       - B) Decoupled (MCTS implements a standard interface)
-    - **Recommended**: Option A - MCTS logic is inextricably tied to the exact rules version and point values.
+   - **Recommended**: Option A - MCTS logic is inextricably tied to the exact rules version and point values.
 
 ## 12. Integration with `vindicta-oracle` (RAG / Rules)
 
 56. **Live Queries**: Can the MCTS proactively query the Oracle during evaluation for unknown edge case rulings?
-    - **Options**:
+   - **Options**:
       - A) Yes (Synchronous RAG during search - extremely slow)
       - B) No (Oracle is used only for pre-processing or post-search logging)
       - C) Pre-cached (Oracle pre-generates common ruling summaries into the engine)
-    - **Recommended**: Option C - Oracle should bake "Rule Interpretations" into the Engine's move generator at startup.
+   - **Recommended**: Option C - Oracle should bake "Rule Interpretations" into the Engine's move generator at startup.
 
 57. **Pre-Validation**: Does the Oracle pre-validate the root node board state before an expensive search is initialized?
-    - **Options**:
+   - **Options**:
       - A) Yes (Ensure the starting position is legal)
       - B) No (Search anyway; illegal states will naturally have low win % or errors)
-    - **Recommended**: Option A - Prevents "Garbage In, Garbage Out" scenarios.
+   - **Recommended**: Option A - Prevents "Garbage In, Garbage Out" scenarios.
 
 58. **Illegality Penalties**: If the Oracle flags a strategy sequence as "illegal", is the branch pruned or heavily mathematically penalized?
-    - **Options**:
+   - **Options**:
       - A) Pruned (Immediate removal)
       - B) Penalized (Give it a -10,000 score, but keep it in the tree for trace visibility)
-    - **Recommended**: Option B - Keeping the branch with a massive penalty allows developers to see *why* the AI "wanted" to cheat.
+   - **Recommended**: Option B - Keeping the branch with a massive penalty allows developers to see *why* the AI "wanted" to cheat.
 
 59. **Caching**: Are Oracle queries cached globally per engine instance or flushed after every search?
-    - **Options**:
+   - **Options**:
       - A) Persistent (Global cache across all matches)
       - B) Session-scoped (Flushed after turn ends)
       - C) None
-    - **Recommended**: Option A - Rules donor change; keep them cached for the life of the container.
+   - **Recommended**: Option A - Rules donor change; keep them cached for the life of the container.
 
 60. **Blame Attribution**: How does MCTS attribute a win/loss specifically to a complex Oracle rules interpretation in its logs?
-    - **Options**:
+   - **Options**:
       - A) Specific Trace Tags (e.g. `ruling_id: 1234`)
       - B) Custom Log Level (Oracle Impact Level)
       - C) Narrative summary
-    - **Recommended**: Option A - Allows automated analysis of which "Rules Interpretations" lead to the highest win rates.
+   - **Recommended**: Option A - Allows automated analysis of which "Rules Interpretations" lead to the highest win rates.
 
 ## 13. Integration with `Vindicta-Agents`
 
 61. **Personality Bias**: Do Agents pass "personality" parameter weights into the MCTS to bias certain playstyles (aggressive vs defensive)?
-    - **Options**:
+   - **Options**:
       - A) Yes (Heuristic weights are passed in the request header)
       - B) No (MCTS is always "Optimal"; Agents decide which optimal move to take)
       - C) Mixed (Base weights are fixed, but agents can suggest "Focus Units")
-    - **Recommended**: Option A - Different agent personalities (e.g. World Eaters vs Tau) require fundamentally different exploration biases to feel "correct".
+   - **Recommended**: Option A - Different agent personalities (e.g. World Eaters vs Tau) require fundamentally different exploration biases to feel "correct".
 
 62. **Polling Frequency**: How often are Agents expected or allowed to poll the Engine for move suggestions?
-    - **Options**:
+   - **Options**:
       - A) Once per turn (Full plan generation)
       - B) Once per phase (Movement, Shooting, etc.)
       - C) Reactive (Whenever the GameState changes)
-    - **Recommended**: Option B - Phase-level polling allows for adjustments based on actual dice results without overwhelming the engine.
+   - **Recommended**: Option B - Phase-level polling allows for adjustments based on actual dice results without overwhelming the engine.
 
 63. **Partial Trees**: Can Agents request partial tree subsets (e.g., "what if I only move unit X") rather than the global best move?
-    - **Options**:
+   - **Options**:
       - A) Yes (Request scoped to specific unit IDs)
       - B) No (Search is always holistic)
-    - **Recommended**: Option A - Unit-scoped search is much faster for "Quick Look" scenarios.
+   - **Recommended**: Option A - Unit-scoped search is much faster for "Quick Look" scenarios.
 
 64. **Payload Syntax**: Do Agents send raw text via `warscribe-system` to the engine, or parsed JSON structures directly?
-    - **Options**:
+   - **Options**:
       - A) Raw Text (Engine handles parsing - high error risk)
       - B) Parsed JSON (Agents must use `warscribe-parser` first)
-    - **Recommended**: Option B - MCTS should only receive clean, mathematical JSON state.
+   - **Recommended**: Option B - MCTS should only receive clean, mathematical JSON state.
 
 65. **Interrupts**: How are real-time Agent interruptions (e.g., an opponent suddenly plays a stratagem) injected to halt the search?
-    - **Options**:
+   - **Options**:
       - A) Signal-based (SIGINT to the process)
       - B) Polling (Engine checks a "Halt" flag in a shared cache)
       - C) Connection Drop (Closing the socket kills the search)
-    - **Recommended**: Option C - Standard socket-level interruption is the cleanest for microservice architectures.
+   - **Recommended**: Option C - Standard socket-level interruption is the cleanest for microservice architectures.
 
 ## 14. Integration with `vindicta-economy`
 
 66. **Compute Bounding**: Is the total MCTS search depth bounded dynamically by a user's Gas Tank / token balance?
-    - **Options**:
+   - **Options**:
       - A) Yes (Depth is capped based on prepaid tokens)
       - B) No (Search completes, and user is billed after)
-    - **Recommended**: Option A - Preventing "Bill Shock" by capping compute at the request level is safer for the platform.
+   - **Recommended**: Option A - Preventing "Bill Shock" by capping compute at the request level is safer for the platform.
 
 67. **Cost Metric**: How are compute costs calculated and billed (seconds of CPU time vs total nodes searched)?
-    - **Options**:
+   - **Options**:
       - A) CPU Time (Ms used)
       - B) Node Count (Total unique states visited)
       - C) Tiered (Fixed price for Depth 2, Depth 3, etc.)
-    - **Recommended**: Option B - Node count is the most hardware-agnostic metric for fair billing.
+   - **Recommended**: Option B - Node count is the most hardware-agnostic metric for fair billing.
 
 68. **Depth Premiums**: Does requesting a deeper search (e.g., Depth 5) automatically deduct more economy tokens?
-    - **Options**:
+   - **Options**:
       - A) Linear (Price = Depth * X)
       - B) Exponential (Price = BranchingFactor ^ Depth)
       - C) Fixed
-    - **Recommended**: Option B - Computational cost for MCTS is exponential; the price should reflect that reality.
+   - **Recommended**: Option B - Computational cost for MCTS is exponential; the price should reflect that reality.
 
 69. **Mid-Search Exhaustion**: What is the behavior if an account runs out of tokens while a search is actively processing at Depth 2?
-    - **Options**:
+   - **Options**:
       - A) Immediate Kill (Discard all results)
       - B) Graceful Return (Return the best found results so far, bill the partial amount)
-    - **Recommended**: Option B - Users should still get what they paid for up to the point of exhaustion.
+   - **Recommended**: Option B - Users should still get what they paid for up to the point of exhaustion.
 
 70. **Free Tiers**: Are cached Principal Variations or shallow Depth 1 estimations provided at zero token cost?
-    - **Options**:
+   - **Options**:
       - A) Yes (Encourage use for basic validation)
       - B) No (All compute is metered)
-    - **Recommended**: Option A - Providing shallow "Sanity Checks" for free improves the ecosystem's developer experience.
+   - **Recommended**: Option A - Providing shallow "Sanity Checks" for free improves the ecosystem's developer experience.
 
 ## 15. Integration with `warscribe-system`
 
 71. **Output Notation**: Is the resulting Principal Variation (best line of play) automatically translated back into standard Warscribe notation?
-    - **Options**:
+   - **Options**:
       - A) Yes (Engine includes a `notation` field in response)
       - B) No (A separate `warscribe-encoder` service handles translation)
-    - **Recommended**: Option B - Keep the Engine purely mathematical; offload NLP/Notation logic to specialized services.
+   - **Recommended**: Option B - Keep the Engine purely mathematical; offload NLP/Notation logic to specialized services.
 
 72. **Input Parsing**: Are incoming GameStates natively parsed from Warscribe text logs before initializing the root node?
-    - **Options**:
+   - **Options**:
       - A) Yes (Support text-to-search)
       - B) No (Require pre-parsed state)
-    - **Recommended**: Option B - Explicit separation of concerns.
+   - **Recommended**: Option B - Explicit separation of concerns.
 
 73. **Ambiguity Handling**: How are ambiguous Warscribe commands (e.g., "move forward") deterministically mapped to specific MCTS coordinates?
-    - **Options**:
+   - **Options**:
       - A) Closest Legal (Engine guesses based on rules)
       - B) Error Out (Require exact coordinates)
       - C) Multi-branch (MCTS searches all possible interpretations of the ambiguity)
-    - **Recommended**: Option C - If a command is vague, the MCTS should search the top 3-5 interpretations and see which is strongest.
+   - **Recommended**: Option C - If a command is vague, the MCTS should search the top 3-5 interpretations and see which is strongest.
 
 74. **Narrative Export**: Does the MCTS output support including generated narrative explanations attached to the Warscribe output?
-    - **Options**:
+   - **Options**:
       - A) Yes (e.g. "AI chose this to block the charge lane")
       - B) No (Mathematical scores only)
-    - **Recommended**: Option B - MCTS handles "Why mathematically"; a separate LLM layer should handle "Why narratively".
+   - **Recommended**: Option B - MCTS handles "Why mathematically"; a separate LLM layer should handle "Why narratively".
 
 75. **Nested Sequences**: How are complex nested sequences (like a prolonged fight phase) represented in Warscribe coming from flattened MCTS branches?
-    - **Options**:
+   - **Options**:
       - A) Sequence IDs (Group nodes by Battle Round/Phase/Interaction)
-    - **Recommended**: Option A - Structured sequence IDs are necessary for multi-phase verification.
+   - **Recommended**: Option A - Structured sequence IDs are necessary for multi-phase verification.
 
 ## 16. Integration with `vindicta-platform` (Backend API)
 
 76. **Microservice Topology**: Does the Engine run as an isolated pod communicating via gRPC, or an embedded library?
-    - **Options**:
+   - **Options**:
       - A) Isolated Pod (gRPC/Protobuf)
       - B) Embedded Library (Imported directly into the Gateway)
       - C) Sidecar (Runs alongside the Game Manager)
-    - **Recommended**: Option A - Isolation allows scaling the compute-heavy Engine independently from the I/O-heavy Gateway.
+   - **Recommended**: Option A - Isolation allows scaling the compute-heavy Engine independently from the I/O-heavy Gateway.
 
 77. **Autoscaling Policy**: How are Engine instances autoscaled in Kubernetes (by message queue length, CPU utilization, or concurrent matches)?
-    - **Options**:
+   - **Options**:
       - A) Queue Length (NATS/RabbitMQ depth)
       - B) CPU Utilization (Standard HPA)
       - C) Custom (HPA based on "Active Search" count)
-    - **Recommended**: Option C - Since MCTS is a continuous "5-second burst", scaling based on the number of concurrently active searches prevents overloading nodes.
+   - **Recommended**: Option C - Since MCTS is a continuous "5-second burst", scaling based on the number of concurrently active searches prevents overloading nodes.
 
 78. **Session Pinning**: Are long-running game sessions pinned to specific Engine pods to maximize transposition table cache hits?
-    - **Options**:
+   - **Options**:
       - A) Yes (Sticky sessions via Ingress)
       - B) No (Any Engine can handle any request; cache is shared/external)
-    - **Recommended**: Option A - Transposition tables are too large to share efficiently; pinning dramatically increases performance.
+   - **Recommended**: Option A - Transposition tables are too large to share efficiently; pinning dramatically increases performance.
 
 79. **Client Disconnects**: How are network partitions or sudden client disconnects managed while an evaluation is running?
-    - **Options**:
+   - **Options**:
       - A) Terminate Search (Save compute)
       - B) Complete & Cache (Complete the search and store the result for 1 min)
-    - **Recommended**: Option B - If the client reconnects quickly, the result is immediately available.
+   - **Recommended**: Option B - If the client reconnects quickly, the result is immediately available.
 
 80. **Transport Protocol**: Is the main MCTS query API strictly synchronous REST, or asynchronously managed via WebHooks/WebSockets?
-    - **Options**:
+   - **Options**:
       - A) Synchronous (Request/Response)
       - B) Asynchronous (Submit Task -> Receive Callback/Webhook)
       - C) Streaming (WebSockets)
-    - **Recommended**: Option B - Mandatory for any task that takes >1 second to prevent gateway timeouts.
+   - **Recommended**: Option B - Mandatory for any task that takes >1 second to prevent gateway timeouts.
 
 ## 17. Simulation & Self-Play Infrastructure
 
 81. **Heuristic Tuning**: Does the ecosystem support the Engine playing against itself internally to automatically tune heuristics?
-    - **Options**:
+   - **Options**:
       - A) Yes (Continuous self-play loop)
       - B) No (Heuristics are tuned manually by rules experts)
-    - **Recommended**: Option A - Data-driven tuning is the only way to achieve "Stockfish" level accuracy.
+   - **Recommended**: Option A - Data-driven tuning is the only way to achieve "Stockfish" level accuracy.
 
 82. **Record Storage**: Where and how are self-play game records continuously archived for offline analysis?
-    - **Options**:
+   - **Options**:
       - A) Object Storage (S3/GCS as Parquet/Avro files)
       - B) SQL Database (Metadata only)
       - C) Search Tree Dumps
-    - **Recommended**: Option A - Parquet is ideal for training future neural network models.
+   - **Recommended**: Option A - Parquet is ideal for training future neural network models.
 
 83. **Elo Rating**: Is there a continuous integration step that gates deployment if the new Engine's Elo rating fails to beat the prior version?
-    - **Options**:
+   - **Options**:
       - A) Yes (CI runs N self-play matches before Merge)
       - B) No (Functional tests only)
-    - **Recommended**: Option A - Regression testing in game AI MUST include "Strength Verification".
+   - **Recommended**: Option A - Regression testing in game AI MUST include "Strength Verification".
 
 84. **Opening Books**: How are early-game "opening book" libraries generated and indexed from these self-play iterations?
-    - **Options**:
+   - **Options**:
       - A) Hash Map (Lookup by Board Hash)
       - B) SQL Index (Common turn 1 deployments)
-    - **Recommended**: Option A - Fast O(1) lookup for common turn 1 layouts.
+   - **Recommended**: Option A - Fast O(1) lookup for common turn 1 layouts.
 
 85. **Opponent Generation**: Does the Engine use specific adversarial matchmaking algorithms during self-play training?
-    - **Options**:
+   - **Options**:
       - A) Self (Newest vs Newest)
       - B) Ancestral (Newest vs Random prior versions)
       - C) Diversified (Aggressive Heuristic vs Defensive Heuristic)
-    - **Recommended**: Option B - Standard practice to prevent "strategy collapse" or overfitting.
+   - **Recommended**: Option B - Standard practice to prevent "strategy collapse" or overfitting.
 
 ## 18. Testing Strategy & Determinism
 
 86. **Strict Determinism**: Must the MCTS engine guarantee 100% deterministic output trees given a fixed integer seed?
-    - **Options**:
+   - **Options**:
       - A) Yes (Mandatory for regression testing)
       - B) No (Accept stochastic noise)
-    - **Recommended**: Option A - Non-deterministic AI is impossible to debug at scale.
+   - **Recommended**: Option A - Non-deterministic AI is impossible to debug at scale.
 
 87. **Mocking**: How do we mock the Entropy Buffer robustly for unit testing tree depth generation?
-    - **Options**:
+   - **Options**:
       - A) Fixed Returns (Roll 3 always returns 3)
       - B) Static Distributions (JSON files representing the curve)
       - C) Mathematical Proxy (Simple Gaussian function)
-    - **Recommended**: Option B - Using real data snapshots for mocks ensures the math logic handles "swingy" edge cases correctly.
+   - **Recommended**: Option B - Using real data snapshots for mocks ensures the math logic handles "swingy" edge cases correctly.
 
 88. **Regression Baselines**: Are there standardized regression scenario suites to ensure evaluation logic doesn't mathematically drift over time?
-    - **Options**:
+   - **Options**:
       - A) Yes (Suite of 100 "Puzzle" board states with expected scores)
       - B) No (Focus on unit test coverage)
-    - **Recommended**: Option A - "Chess Puzzles" for 40k are essential for verifying heuristic changes.
+   - **Recommended**: Option A - "Chess Puzzles" for 40k are essential for verifying heuristic changes.
 
 89. **Memory Profiling**: Which tools are mandated for testing memory leaks and fragmentation in the custom arena allocator?
-    - **Options**:
+   - **Options**:
       - A) Valgrind / Memcheck (Requires C-extensions)
       - B) `tracemalloc` / `objgraph` (Python-native)
       - C) Prometheus Memory Metrics
-    - **Recommended**: Option B - Standard for uv/Python 3.12 workspaces.
+   - **Recommended**: Option B - Standard for uv/Python 3.12 workspaces.
 
 90. **Coverage Gates**: What minimum percentage of BDD scenario coverage is expected strictly for MCTS extreme edge cases?
-    - **Options**:
+   - **Options**:
       - A) 90% (Project Standard)
       - B) 100% (Intent-to-Execution Mandate)
-    - **Recommended**: Option B - Essential for the core math modules as per `TDD_SKILL.md`.
+   - **Recommended**: Option B - Essential for the core math modules as per `TDD_SKILL.md`.
 
 ## 19. Security, Cheating, and Sandboxing
 
 91. **Payload Sanitization**: Could a maliciously crafted JSON GameState payload force the engine into an infinite parsing loop?
-    - **Options**:
+   - **Options**:
       - A) Yes (If recursive parser is used without depth limits)
       - B) No (JSON schemas and standard library parsers enforce strict limits)
-    - **Recommended**: Option B - Standardizing on `orjson` or `pydantic` with strict recursive depth guards is sufficient.
+   - **Recommended**: Option B - Standardizing on `orjson` or `pydantic` with strict recursive depth guards is sufficient.
 
 92. **Timeout Enforcement**: Are client connection timeouts and search time limits enforced strictly by the orchestrator or internally by the engine?
-    - **Options**:
+   - **Options**:
       - A) Internal (Engine monitors its own clock)
       - B) External (API Gateway kills the socket)
       - C) Dual (Both)
-    - **Recommended**: Option C - Redundant enforcement is required for high-availability systems.
+   - **Recommended**: Option C - Redundant enforcement is required for high-availability systems.
 
 93. **Hidden Objective Fishing**: Can malicious clients extract hidden opponent objectives by repeatedly probing the MCTS with targeted queries?
-    - **Options**:
+   - **Options**:
       - A) Yes (By observing score spikes for specific moves)
       - B) No (Search tree is scrubbed of all hidden state data before return)
-    - **Recommended**: Option B - "What the UI doesn't need, it shouldn't see."
+   - **Recommended**: Option B - "What the UI doesn't need, it shouldn't see."
 
 94. **Response Scrubbing**: Is the returned search tree sanitized to remove opponent-hidden states before dispatch to the client?
-    - **Options**:
+   - **Options**:
       - A) Yes (Sanitize `GameNode` metadata)
       - B) No (Metadata is already abstracted enough)
-    - **Recommended**: Option A - Mandatory for competitive integrity.
+   - **Recommended**: Option A - Mandatory for competitive integrity.
 
 95. **Rate Limiting**: At what gateway layer is MCTS evaluation request rate-limiting applied per user account?
-    - **Options**:
+   - **Options**:
       - A) NGINX / Network Ingress
       - B) Internal Engine Quota
       - C) Economy Layer (Gas Tank)
-    - **Recommended**: Option C - Tying compute strictly to the `Gas Tank` economy naturally limits abuse.
+   - **Recommended**: Option C - Tying compute strictly to the `Gas Tank` economy naturally limits abuse.
 
 ## 20. Frontend & `vindicta-platform.github.io`
 
 96. **Visual Overlays**: Does the single-page web frontend render MCTS evaluations visually (e.g., win probability bar graphs)?
-    - **Options**:
+   - **Options**:
       - A) Yes (Live-updating charts)
       - B) No (Text logs only)
-    - **Recommended**: Option A - Visualizing the "Swing" of a turn is a key feature of the platform.
+   - **Recommended**: Option A - Visualizing the "Swing" of a turn is a key feature of the platform.
 
 97. **Map Projections**: Are Principal Variations projected as movement arrows and pathing indicators on a 2D map in the browser?
-    - **Options**:
+   - **Options**:
       - A) Yes (SVG pathing overlays)
       - B) No (Coordinate lists only)
-    - **Recommended**: Option A - Visualizing "The AI's Intent" makes the platform significantly more usable for players.
+   - **Recommended**: Option A - Visualizing "The AI's Intent" makes the platform significantly more usable for players.
 
 98. **Fast What-Ifs**: Can the frontend request asynchronous "what-if" fast evaluations without committing to a turn?
-    - **Options**:
+   - **Options**:
       - A) Yes (Low-depth Depth 1 searches)
       - B) No (Only full turn evaluations allowed)
-    - **Recommended**: Option A - Allows players to "Check their Math" on move ideas.
+   - **Recommended**: Option A - Allows players to "Check their Math" on move ideas.
 
 99. **Loading States**: Flow-wise, how does the frontend UI gracefully handle the mandatory 5-second asynchronous loading states?
-    - **Options**:
+   - **Options**:
       - A) Skeleton Screens (Representing the board)
       - B) Progress Bar (Showing search depth progress)
       - C) Narrative Stream (Live log of what the AI is "thinking")
-    - **Recommended**: Option C - Streaming "Thinking..." logs is the most engaging way to handle high-latency AI tasks.
+   - **Recommended**: Option C - Streaming "Thinking..." logs is the most engaging way to handle high-latency AI tasks.
 
 100. **Client-Side Engine**: Are lightweight WASM (WebAssembly) versions of the MCTS engine planned for offloading compute to the browser?
-    - **Options**:
+   - **Options**:
        - A) Yes (Future Roadmap)
        - B) No (Keep compute behind the API for Prop/IP protection)
-    - **Recommended**: Option B - Competitive game logic should stay on the server to prevent cheating and reverse-engineering of the evaluation weights.
+   - **Recommended**: Option B - Competitive game logic should stay on the server to prevent cheating and reverse-engineering of the evaluation weights.

--- a/044-mcts-foundation/extended_clarifications.md
+++ b/044-mcts-foundation/extended_clarifications.md
@@ -1,71 +1,73 @@
-# Extended Clarifications: FEAT-044 MCTS Engine Foundation
+﻿# Extended Clarifications: FEAT-044 MCTS Engine Foundation
 
-The following 100 questions span 20 distinct categories regarding the architecture, integration, and operational constraints of the MCTS Engine within the broader `vindicta-platform-testing` ecosystem. 
+The following 100 questions span 20 distinct categories regarding the architecture, integration, and operational constraints of the MCTS Engine within the broader `vindicta-platform-testing` ecosystem.
 
 For each, please provide a short answer or select an option to guide the technical planning.
 
 ## 1. GameState Representation (Data Model)
+
 1. **Encoding**: How are unit properties and locations explicitly encoded in memory (e.g., bitboards, struct arrays, entity-component)?
    - **Options**:
-     - A) Bitboards (High efficiency, requires complex bitmasking logic)
-     - B) Typed NumPy Arrays / Struct Arrays (Fast attribute access, easy vectorization)
-     - C) Pydantic/VindictaModel classes (High abstraction, slower for high-frequency tree nodes)
+    - A) Bitboards (High efficiency, requires complex bitmasking logic)
+    - B) Typed NumPy Arrays / Struct Arrays (Fast attribute access, easy vectorization)
+    - C) Pydantic/VindictaModel classes (High abstraction, slower for high-frequency tree nodes)
    - **Recommended**: Option B - NumPy arrays offer a balance of Python-native readability and near-C performance for state snapshots.
 
 2. **Hidden Information**: Is the board state passed to the MCTS fully observable, or are hidden secondary objectives obfuscated?
    - **Options**:
-     - A) Fully Observable (Standard MCTS, simpler implementation)
-     - B) Partially Observable (Information Set MCTS, handles fog-of-war/hidden cards)
-     - C) Cheating AI (AI sees all, but pretends not to)
+    - A) Fully Observable (Standard MCTS, simpler implementation)
+    - B) Partially Observable (Information Set MCTS, handles fog-of-war/hidden cards)
+    - C) Cheating AI (AI sees all, but pretends not to)
    - **Recommended**: Option A - For a foundation layer, perfect information simplifies the search; hidden info can be modeled as "expected value" branches later.
 
 3. **Serialization**: What serialization format is used for network transfer of GameStates (e.g., JSON, Protocol Buffers, FlatBuffers)?
    - **Options**:
-     - A) JSON (Human readable, high overhead)
-     - B) Protocol Buffers (Compact, fast, typed)
-     - C) FlatBuffers (Zero-copy, fastest but more complex schema management)
+    - A) JSON (Human readable, high overhead)
+    - B) Protocol Buffers (Compact, fast, typed)
+    - C) FlatBuffers (Zero-copy, fastest but more complex schema management)
    - **Recommended**: Option B - Protobuf provides the best middle ground for the `vindicta-platform` microservice mesh.
 
 4. **Terrain**: How is 3D terrain conceptually represented in the mathematical snapshot to calculate line-of-sight efficiently?
    - **Options**:
-     - A) Voxel Grid (High precision, memory intensive)
-     - B) 2D Heightmap + Obstacle Polygons (Simpler LoS math)
-     - C) Abstract Keyword Tags (e.g., "Obscuring") with simplified bounding boxes
+    - A) Voxel Grid (High precision, memory intensive)
+    - B) 2D Heightmap + Obstacle Polygons (Simpler LoS math)
+    - C) Abstract Keyword Tags (e.g., "Obscuring") with simplified bounding boxes
    - **Recommended**: Option C - Standardizing on "Obscuring" / "Cover" tags aligns with the core game engine logic rules.
 
 5. **Aura Effects**: Are aura effects computed dynamically during evaluation, or are they statically attached as state flags per unit?
    - **Options**:
-     - A) Dynamic (Computed on-demand, always accurate)
-     - B) Static Flags (Pre-calculated at start of phase/turn, faster but risk of staleness)
-     - C) Incremental (Updated only when a unit moves)
+    - A) Dynamic (Computed on-demand, always accurate)
+    - B) Static Flags (Pre-calculated at start of phase/turn, faster but risk of staleness)
+    - C) Incremental (Updated only when a unit moves)
    - **Recommended**: Option B - Statically attaching flags during a "Snapshot Refresh" phase significantly speeds up playout evaluations.
 
 ## 2. Move Generation Logic
+
 6. **Laziness**: Are child moves generated lazily (on demand per expanded node) or eagerly (all at once per state)?
    - **Options**:
-     - A) Lazy (Lower memory, slower leaf expansion)
-     - B) Eager (Faster search, higher memory usage per node)
+    - A) Lazy (Lower memory, slower leaf expansion)
+    - B) Eager (Faster search, higher memory usage per node)
    - **Recommended**: Option A - For Depth 3+, lazy expansion prevents generating thousands of unused move branches for low-probability nodes.
 
 7. **Compound Actions**: How are compound action sequences (e.g., move, then shoot, then charge) segmented into decision nodes?
    - **Options**:
-     - A) Flattened (All permutations are siblings at one depth)
-     - B) Phase-Sequential (Move node -> Shoot node -> Charge node)
-     - C) Action Bundling (Agents submit an "Entire Turn Plan" as one branch)
+    - A) Flattened (All permutations are siblings at one depth)
+    - B) Phase-Sequential (Move node -> Shoot node -> Charge node)
+    - C) Action Bundling (Agents submit an "Entire Turn Plan" as one branch)
    - **Recommended**: Option B - Multi-step sequential nodes better represent the reactive nature of stratagems and dice outcomes.
 
 8. **Measurements**: How does the generator handle continuous distances (e.g., 6" move) in a discrete search tree?
    - **Options**:
-     - A) Discretized Grid (Move 1, 2, 3... inches)
-     - B) Cardinal Directions (Fixed point navigation)
-     - C) Cluster-Based (Only generate moves to "meaningful" objective or cover zones)
+    - A) Discretized Grid (Move 1, 2, 3... inches)
+    - B) Cardinal Directions (Fixed point navigation)
+    - C) Cluster-Based (Only generate moves to "meaningful" objective or cover zones)
    - **Recommended**: Option C - Moving to "points of interest" reduces the branching factor from infinite to manageable.
 
 9. **Stratagems**: Are CP usage and reactive stratagems considered standard "moves" in the tree?
    - **Options**:
-     - A) Yes (Full decision tree including resource management)
-     - B) No (Stratagems are handled by a separate heuristic "override" layer)
-     - C) Dynamic Pruning (Only include critical CP moves like "Interrupt")
+    - A) Yes (Full decision tree including resource management)
+    - B) No (Stratagems are handled by a separate heuristic "override" layer)
+    - C) Dynamic Pruning (Only include critical CP moves like "Interrupt")
    - **Recommended**: Option C - Pruning CP usage to only high-impact actions keeps the breadth manageable.
 
 10. **Fail States**: How are "Fail" scenarios (e.g., a failed 9" charge) mapped to branch continuations?
@@ -76,6 +78,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option A - Real branches for success/failure are essential for risk-assessment logic in MCTS.
 
 ## 3. MCTS Node Expansion & Selection
+
 11. **UCT Formula**: What variant of the Upper Confidence Bound applied to Trees (UCT) formula will govern node selection?
     - **Options**:
       - A) Standard UCT1 (Exploration vs Exploitation balance)
@@ -111,6 +114,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option A - Prevents the AI from "shuffling" or delaying a win when an immediate advantage is available.
 
 ## 4. Entropy Buffer Integration
+
 16. **Expectation Strategy**: How are results derived from the Entropy Buffer (mean averages vs distribution sampling per rollout)?
     - **Options**:
       - A) Mean Average (Deterministic, fast, but "boring" play)
@@ -147,6 +151,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option B - Caching the Top 500 most common dice interactions (e.g., 20 S4 shots into T4) is the best performance win.
 
 ## 5. Evaluation Heuristics (Static Evaluation)
+
 21. **Scoring Weights**: What is the relative weight ratio between VP lead, Material advantage, and Positional control?
     - **Options**:
       - A) Material Dominant (Kill everything first)
@@ -182,6 +187,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option B - Since secondaries are highly specific (e.g., "Behind Enemy Lines"), they require explicit sub-logic.
 
 ## 6. Time Management & Search Constraints
+
 26. **Budget Distribution**: How does the engine distribute the 5-second budget across iterative deepening phases?
     - **Options**:
       - A) Fixed % (e.g., 20% for Depth 1, 30% for Depth 2, 50% for Depth 3)
@@ -211,10 +217,11 @@ For each, please provide a short answer or select an option to guide the technic
     - **Options**:
       - A) Return Result (Stop and save the computation cost)
       - B) Iterative Deepening (Proceed to Depth 4+ until time runs out)
-     - C) Statistical Softening (Use remaining time to run more rollouts on current leaves)
+    - C) Statistical Softening (Use remaining time to run more rollouts on current leaves)
     - **Recommended**: Option B - If time remains, deeper search is always better for accuracy.
 
 ## 7. Concurrency & Parallelization
+
 31. **Threading Model**: Does the search employ Root Parallelism, Leaf Parallelism, or Tree Parallelism?
     - **Options**:
       - A) Root Parallelism (Run N independent trees, merge results at end - easiest)
@@ -250,6 +257,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option A - Determinism is a strict requirement for `vindicta-platform` to ensure audit trails and repeatable tests.
 
 ## 8. Pruning & Tree Reduction
+
 36. **Forward Pruning**: Is Forward Pruning aggressively applied to moves with historically low immediate payouts?
     - **Options**:
       - A) Yes (Only consider Top N most promising moves)
@@ -284,6 +292,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option A - Pruning extreme outliers keeps the tree representation sane and focused on realistic outcomes.
 
 ## 9. Observability, Tracing, and Logging
+
 41. **Trace Format**: What industry-standard format is used for exported traces (OpenTelemetry, JSON logs)?
     - **Options**:
       - A) OpenTelemetry (OTLP) (Native support for Jaeger/Grafana)
@@ -319,6 +328,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option B - Seven days allows for retroactive post-mortem analysis of failed game sessions.
 
 ## 10. Hardware & Resource Limits
+
 46. **Hardware Acceleration**: Are neural network evaluations (if added later) explicitly targeted for CPU or GPU hardware?
     - **Options**:
       - A) CPU Only (Focus on vectorized AVX/SIMD instructions)
@@ -355,6 +365,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option C - The codebase should be multi-arch, but ARM64 is the preferred production target for cost.
 
 ## 11. Integration with `vindicta-engine` (Core Logic)
+
 51. **Logic Duplication**: Does MCTS duplicate `vindicta-engine`'s rules internally for speed, or call the module directly?
     - **Options**:
       - A) Call Directly (Maintainable, slower)
@@ -390,6 +401,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option A - MCTS logic is inextricably tied to the exact rules version and point values.
 
 ## 12. Integration with `vindicta-oracle` (RAG / Rules)
+
 56. **Live Queries**: Can the MCTS proactively query the Oracle during evaluation for unknown edge case rulings?
     - **Options**:
       - A) Yes (Synchronous RAG during search - extremely slow)
@@ -424,6 +436,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option A - Allows automated analysis of which "Rules Interpretations" lead to the highest win rates.
 
 ## 13. Integration with `Vindicta-Agents`
+
 61. **Personality Bias**: Do Agents pass "personality" parameter weights into the MCTS to bias certain playstyles (aggressive vs defensive)?
     - **Options**:
       - A) Yes (Heuristic weights are passed in the request header)
@@ -458,6 +471,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option C - Standard socket-level interruption is the cleanest for microservice architectures.
 
 ## 14. Integration with `vindicta-economy`
+
 66. **Compute Bounding**: Is the total MCTS search depth bounded dynamically by a user's Gas Tank / token balance?
     - **Options**:
       - A) Yes (Depth is capped based on prepaid tokens)
@@ -491,6 +505,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option A - Providing shallow "Sanity Checks" for free improves the ecosystem's developer experience.
 
 ## 15. Integration with `warscribe-system`
+
 71. **Output Notation**: Is the resulting Principal Variation (best line of play) automatically translated back into standard Warscribe notation?
     - **Options**:
       - A) Yes (Engine includes a `notation` field in response)
@@ -522,6 +537,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option A - Structured sequence IDs are necessary for multi-phase verification.
 
 ## 16. Integration with `vindicta-platform` (Backend API)
+
 76. **Microservice Topology**: Does the Engine run as an isolated pod communicating via gRPC, or an embedded library?
     - **Options**:
       - A) Isolated Pod (gRPC/Protobuf)
@@ -556,6 +572,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option B - Mandatory for any task that takes >1 second to prevent gateway timeouts.
 
 ## 17. Simulation & Self-Play Infrastructure
+
 81. **Heuristic Tuning**: Does the ecosystem support the Engine playing against itself internally to automatically tune heuristics?
     - **Options**:
       - A) Yes (Continuous self-play loop)
@@ -589,6 +606,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option B - Standard practice to prevent "strategy collapse" or overfitting.
 
 ## 18. Testing Strategy & Determinism
+
 86. **Strict Determinism**: Must the MCTS engine guarantee 100% deterministic output trees given a fixed integer seed?
     - **Options**:
       - A) Yes (Mandatory for regression testing)
@@ -622,6 +640,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option B - Essential for the core math modules as per `TDD_SKILL.md`.
 
 ## 19. Security, Cheating, and Sandboxing
+
 91. **Payload Sanitization**: Could a maliciously crafted JSON GameState payload force the engine into an infinite parsing loop?
     - **Options**:
       - A) Yes (If recursive parser is used without depth limits)
@@ -655,6 +674,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option C - Tying compute strictly to the `Gas Tank` economy naturally limits abuse.
 
 ## 20. Frontend & `vindicta-platform.github.io`
+
 96. **Visual Overlays**: Does the single-page web frontend render MCTS evaluations visually (e.g., win probability bar graphs)?
     - **Options**:
       - A) Yes (Live-updating charts)
@@ -681,7 +701,7 @@ For each, please provide a short answer or select an option to guide the technic
     - **Recommended**: Option C - Streaming "Thinking..." logs is the most engaging way to handle high-latency AI tasks.
 
 100. **Client-Side Engine**: Are lightweight WASM (WebAssembly) versions of the MCTS engine planned for offloading compute to the browser?
-     - **Options**:
+    - **Options**:
        - A) Yes (Future Roadmap)
        - B) No (Keep compute behind the API for Prop/IP protection)
-     - **Recommended**: Option B - Competitive game logic should stay on the server to prevent cheating and reverse-engineering of the evaluation weights.
+    - **Recommended**: Option B - Competitive game logic should stay on the server to prevent cheating and reverse-engineering of the evaluation weights.

--- a/044-mcts-foundation/extended_clarifications.md
+++ b/044-mcts-foundation/extended_clarifications.md
@@ -8,700 +8,700 @@ For each, please provide a short answer or select an option to guide the technic
 
 1. **Encoding**: How are unit properties and locations explicitly encoded in memory (e.g., bitboards, struct arrays, entity-component)?
    - **Options**:
-   - A) Bitboards (High efficiency, requires complex bitmasking logic)
-   - B) Typed NumPy Arrays / Struct Arrays (Fast attribute access, easy vectorization)
-   - C) Pydantic/VindictaModel classes (High abstraction, slower for high-frequency tree nodes)
+    - A) Bitboards (High efficiency, requires complex bitmasking logic)
+    - B) Typed NumPy Arrays / Struct Arrays (Fast attribute access, easy vectorization)
+    - C) Pydantic/VindictaModel classes (High abstraction, slower for high-frequency tree nodes)
    - **Recommended**: Option B - NumPy arrays offer a balance of Python-native readability and near-C performance for state snapshots.
 
 2. **Hidden Information**: Is the board state passed to the MCTS fully observable, or are hidden secondary objectives obfuscated?
    - **Options**:
-   - A) Fully Observable (Standard MCTS, simpler implementation)
-   - B) Partially Observable (Information Set MCTS, handles fog-of-war/hidden cards)
-   - C) Cheating AI (AI sees all, but pretends not to)
+    - A) Fully Observable (Standard MCTS, simpler implementation)
+    - B) Partially Observable (Information Set MCTS, handles fog-of-war/hidden cards)
+    - C) Cheating AI (AI sees all, but pretends not to)
    - **Recommended**: Option A - For a foundation layer, perfect information simplifies the search; hidden info can be modeled as "expected value" branches later.
 
 3. **Serialization**: What serialization format is used for network transfer of GameStates (e.g., JSON, Protocol Buffers, FlatBuffers)?
    - **Options**:
-   - A) JSON (Human readable, high overhead)
-   - B) Protocol Buffers (Compact, fast, typed)
-   - C) FlatBuffers (Zero-copy, fastest but more complex schema management)
+    - A) JSON (Human readable, high overhead)
+    - B) Protocol Buffers (Compact, fast, typed)
+    - C) FlatBuffers (Zero-copy, fastest but more complex schema management)
    - **Recommended**: Option B - Protobuf provides the best middle ground for the `vindicta-platform` microservice mesh.
 
 4. **Terrain**: How is 3D terrain conceptually represented in the mathematical snapshot to calculate line-of-sight efficiently?
    - **Options**:
-   - A) Voxel Grid (High precision, memory intensive)
-   - B) 2D Heightmap + Obstacle Polygons (Simpler LoS math)
-   - C) Abstract Keyword Tags (e.g., "Obscuring") with simplified bounding boxes
+    - A) Voxel Grid (High precision, memory intensive)
+    - B) 2D Heightmap + Obstacle Polygons (Simpler LoS math)
+    - C) Abstract Keyword Tags (e.g., "Obscuring") with simplified bounding boxes
    - **Recommended**: Option C - Standardizing on "Obscuring" / "Cover" tags aligns with the core game engine logic rules.
 
 5. **Aura Effects**: Are aura effects computed dynamically during evaluation, or are they statically attached as state flags per unit?
    - **Options**:
-   - A) Dynamic (Computed on-demand, always accurate)
-   - B) Static Flags (Pre-calculated at start of phase/turn, faster but risk of staleness)
-   - C) Incremental (Updated only when a unit moves)
+    - A) Dynamic (Computed on-demand, always accurate)
+    - B) Static Flags (Pre-calculated at start of phase/turn, faster but risk of staleness)
+    - C) Incremental (Updated only when a unit moves)
    - **Recommended**: Option B - Statically attaching flags during a "Snapshot Refresh" phase significantly speeds up playout evaluations.
 
 ## 2. Move Generation Logic
 
 6. **Laziness**: Are child moves generated lazily (on demand per expanded node) or eagerly (all at once per state)?
    - **Options**:
-   - A) Lazy (Lower memory, slower leaf expansion)
-   - B) Eager (Faster search, higher memory usage per node)
+    - A) Lazy (Lower memory, slower leaf expansion)
+    - B) Eager (Faster search, higher memory usage per node)
    - **Recommended**: Option A - For Depth 3+, lazy expansion prevents generating thousands of unused move branches for low-probability nodes.
 
 7. **Compound Actions**: How are compound action sequences (e.g., move, then shoot, then charge) segmented into decision nodes?
    - **Options**:
-   - A) Flattened (All permutations are siblings at one depth)
-   - B) Phase-Sequential (Move node -> Shoot node -> Charge node)
-   - C) Action Bundling (Agents submit an "Entire Turn Plan" as one branch)
+    - A) Flattened (All permutations are siblings at one depth)
+    - B) Phase-Sequential (Move node -> Shoot node -> Charge node)
+    - C) Action Bundling (Agents submit an "Entire Turn Plan" as one branch)
    - **Recommended**: Option B - Multi-step sequential nodes better represent the reactive nature of stratagems and dice outcomes.
 
 8. **Measurements**: How does the generator handle continuous distances (e.g., 6" move) in a discrete search tree?
    - **Options**:
-   - A) Discretized Grid (Move 1, 2, 3... inches)
-   - B) Cardinal Directions (Fixed point navigation)
-   - C) Cluster-Based (Only generate moves to "meaningful" objective or cover zones)
+    - A) Discretized Grid (Move 1, 2, 3... inches)
+    - B) Cardinal Directions (Fixed point navigation)
+    - C) Cluster-Based (Only generate moves to "meaningful" objective or cover zones)
    - **Recommended**: Option C - Moving to "points of interest" reduces the branching factor from infinite to manageable.
 
 9. **Stratagems**: Are CP usage and reactive stratagems considered standard "moves" in the tree?
    - **Options**:
-   - A) Yes (Full decision tree including resource management)
-   - B) No (Stratagems are handled by a separate heuristic "override" layer)
-   - C) Dynamic Pruning (Only include critical CP moves like "Interrupt")
+    - A) Yes (Full decision tree including resource management)
+    - B) No (Stratagems are handled by a separate heuristic "override" layer)
+    - C) Dynamic Pruning (Only include critical CP moves like "Interrupt")
    - **Recommended**: Option C - Pruning CP usage to only high-impact actions keeps the breadth manageable.
 
 10. **Fail States**: How are "Fail" scenarios (e.g., a failed 9" charge) mapped to branch continuations?
-   - **Options**:
+    - **Options**:
       - A) Stochastic Nodes (Tree branches into "Success" and "Failure" children)
       - B) Weighted Averages (Rollout uses the Entropy Buffer's mean outcome)
       - C) Outcome Sampling (Node represents only the most likely outcome)
-   - **Recommended**: Option A - Real branches for success/failure are essential for risk-assessment logic in MCTS.
+    - **Recommended**: Option A - Real branches for success/failure are essential for risk-assessment logic in MCTS.
 
 ## 3. MCTS Node Expansion & Selection
 
 11. **UCT Formula**: What variant of the Upper Confidence Bound applied to Trees (UCT) formula will govern node selection?
-   - **Options**:
+    - **Options**:
       - A) Standard UCT1 (Exploration vs Exploitation balance)
       - B) PUCT (Predictor + UCB, used in AlphaZero)
       - C) RAVE (Rapid Action Value Estimation)
-   - **Recommended**: Option A - Start with Standard UCT1; it is robust and easiest to tune for the foundation.
+    - **Recommended**: Option A - Start with Standard UCT1; it is robust and easiest to tune for the foundation.
 
 12. **Playout Strategy**: Does the engine use random heavy rollouts or a heuristic shallow evaluation function for unvisited nodes?
-   - **Options**:
+    - **Options**:
       - A) Traditional Rollouts (Simulate game to end - slow in 40k)
       - B) Heuristic Evaluation (Assign score at terminal depth, then backpropagate)
       - C) Hybrid (Short rollout + evaluation)
-   - **Recommended**: Option B - Given the complexity of 40k, a professional heuristic score (Stockfish-style) at Depth 3 is more viable than full rollouts.
+    - **Recommended**: Option B - Given the complexity of 40k, a professional heuristic score (Stockfish-style) at Depth 3 is more viable than full rollouts.
 
 13. **Progressive Unpruning**: Will the engine implement progressive unpruning for branching factors that are initially too large?
-   - **Options**:
+    - **Options**:
       - A) Yes (Gradually add moves as visit count increases)
       - B) No (Evaluate all legal moves from the start)
-   - **Recommended**: Option A - Essential for game states with hundreds of possible shooting/movement permutations.
+    - **Recommended**: Option A - Essential for game states with hundreds of possible shooting/movement permutations.
 
 14. **Transpositions**: How are transposition tables (tracking identical board states reached via different move orders) integrated?
-   - **Options**:
+    - **Options**:
       - A) Zobrist Hashing (Industry standard for chess/Go)
       - B) State Delta Sets (Compare unit-by-unit differences)
       - C) No Transposition (Re-evaluate identical states independently)
-   - **Recommended**: Option A - Zobrist Hashing is mandatory for avoiding redundant computation in iterative deepening.
+    - **Recommended**: Option A - Zobrist Hashing is mandatory for avoiding redundant computation in iterative deepening.
 
 15. **Reward Discounting**: Is there a discount factor applied to rewards deeper in the tree to favor immediate certainty?
-   - **Options**:
+    - **Options**:
       - A) Exponential Decay (Gains far in the future are worth less)
       - B) Discrete Step Penalty (Fixed cost per turn/depth)
       - C) No Discount (Win in 5 turns is same as win in 1)
-   - **Recommended**: Option A - Prevents the AI from "shuffling" or delaying a win when an immediate advantage is available.
+    - **Recommended**: Option A - Prevents the AI from "shuffling" or delaying a win when an immediate advantage is available.
 
 ## 4. Entropy Buffer Integration
 
 16. **Expectation Strategy**: How are results derived from the Entropy Buffer (mean averages vs distribution sampling per rollout)?
-   - **Options**:
+    - **Options**:
       - A) Mean Average (Deterministic, fast, but "boring" play)
       - B) Weighted Distribution Sampling (Probabilistic, more realistic)
       - C) Percentile Pruning (Only consider 25th-75th percentile outcomes)
-   - **Recommended**: Option B - Sampling from the distribution provides the "swinginess" inherent in 40k that MCTS needs to account for.
+    - **Recommended**: Option B - Sampling from the distribution provides the "swinginess" inherent in 40k that MCTS needs to account for.
 
 17. **Re-rolls**: Are re-rolls (e.g., Command Re-roll) resolved instantly within a buffer query or treated as separate decision branches?
-   - **Options**:
+    - **Options**:
       - A) Procedural (Buffer handles re-roll math internally in one call)
       - B) Branching (A re-roll is a separate move node in the tree)
       - C) Heuristic (Add a +X% boost to the initial roll success probability)
-   - **Recommended**: Option A - Having the buffer handle re-roll math internally keeps the tree depth from exploding.
+    - **Recommended**: Option A - Having the buffer handle re-roll math internally keeps the tree depth from exploding.
 
 18. **Granularity**: What is the granularity of dice expectation requests (per single shot vs aggregate per attack sequence)?
-   - **Options**:
+    - **Options**:
       - A) Per Die (Highest precision, extreme latency)
       - B) Per Sequence (e.g., "10 shots at 3+ to hit")
       - C) Per Unit-Phase (Aggregate all attacks from one unit)
-   - **Recommended**: Option B - "Per Sequence" is the standard for efficient 40k math engines.
+    - **Recommended**: Option B - "Per Sequence" is the standard for efficient 40k math engines.
 
 19. **Mortal Wounds**: How are low-probability outlier events (e.g., rolling 6s to wound causing mortal spikes) weighted?
-   - **Options**:
+    - **Options**:
       - A) Ignored (Too rare to model)
       - B) Linear Weighting (Include in the average)
       - C) Importance Sampling (Give outliers higher weight during specific phases)
-   - **Recommended**: Option B - Linear weighting in the distribution sampling ensures they occur at the correct frequency.
+    - **Recommended**: Option B - Linear weighting in the distribution sampling ensures they occur at the correct frequency.
 
 20. **Synchronization**: Does the engine pre-fetch buffer probabilities, or query the buffer synchronously during evaluation?
-   - **Options**:
+    - **Options**:
       - A) Synchronous (Simplest, but creates compute bottlenecks)
       - B) Pre-fetch / Cache (Store common roll results in memory)
       - C) Asynchronous (Parallelize buffer calls, process branches when results return)
-   - **Recommended**: Option B - Caching the Top 500 most common dice interactions (e.g., 20 S4 shots into T4) is the best performance win.
+    - **Recommended**: Option B - Caching the Top 500 most common dice interactions (e.g., 20 S4 shots into T4) is the best performance win.
 
 ## 5. Evaluation Heuristics (Static Evaluation)
 
 21. **Scoring Weights**: What is the relative weight ratio between VP lead, Material advantage, and Positional control?
-   - **Options**:
+    - **Options**:
       - A) Material Dominant (Kill everything first)
       - B) VP Dominant (Focus strictly on objectives)
       - C) Balanced (40% VP, 30% Material, 30% Control)
-   - **Recommended**: Option C - A balanced approach prevents the "passive objective holding" and "pointless bloodlust" extremes.
+    - **Recommended**: Option C - A balanced approach prevents the "passive objective holding" and "pointless bloodlust" extremes.
 
 22. **Dynamic Overrides**: Are these heuristic weights hardcoded, or dynamically loaded via a remote config system?
-   - **Options**:
+    - **Options**:
       - A) Hardcoded (Fastest, requires re-build to change)
       - B) Remote Config / JSON (Flexible, easy to A/B test without deployment)
       - C) Agent-Defined (The calling agent passes the weights in the payload)
-   - **Recommended**: Option B - Using a remote config (as per project guidelines for `remote_config_master.md`) allows tuning without code changes.
+    - **Recommended**: Option B - Using a remote config (as per project guidelines for `remote_config_master.md`) allows tuning without code changes.
 
 23. **Objective Holding**: How is objective control evaluated if the scoring phase is not immediate?
-   - **Options**:
+    - **Options**:
       - A) Sticky Control (Unit is on it now = points eventually)
       - B) Projected Control (Who is likely to have OC on it at the end of the battle round?)
       - C) Distance Weighted (Reward proximity to objective centers)
-   - **Recommended**: Option B - Projected control after all phase nodes resolve is the most accurate for 10th Edition.
+    - **Recommended**: Option B - Projected control after all phase nodes resolve is the most accurate for 10th Edition.
 
 24. **Phase Scaling**: Does the evaluation function scale its priorities based on the current game turn (e.g., late game values VP higher)?
-   - **Options**:
+    - **Options**:
       - A) Yes (Linear scaling of VP weight over 5 turns)
       - B) No (Static evaluation throughout)
-   - **Recommended**: Option A - VP is much more valuable on Turn 5 than Turn 1, where material preservation is key.
+    - **Recommended**: Option A - VP is much more valuable on Turn 5 than Turn 1, where material preservation is key.
 
 25. **Secondary Objectives**: How are player-selected secondary objectives factored into the base heuristic score?
-   - **Options**:
+    - **Options**:
       - A) Global Heuristic (Add points for "Action" completions)
       - B) Explicit Trackers (Separate logic sub-modules per objective)
       - C) Ignored (AI only cares about Primary/Material)
-   - **Recommended**: Option B - Since secondaries are highly specific (e.g., "Behind Enemy Lines"), they require explicit sub-logic.
+    - **Recommended**: Option B - Since secondaries are highly specific (e.g., "Behind Enemy Lines"), they require explicit sub-logic.
 
 ## 6. Time Management & Search Constraints
 
 26. **Budget Distribution**: How does the engine distribute the 5-second budget across iterative deepening phases?
-   - **Options**:
+    - **Options**:
       - A) Fixed % (e.g., 20% for Depth 1, 30% for Depth 2, 50% for Depth 3)
       - B) Adaptive (Stop when time is 90% exhausted regardless of current depth progress)
       - C) Early Exit (Return best move immediately if one line is >95% win prob)
-   - **Recommended**: Option B - Adaptive time-slicing ensures we never miss the 5-second hard limit.
+    - **Recommended**: Option B - Adaptive time-slicing ensures we never miss the 5-second hard limit.
 
 27. **Hard Stops**: Is there an asynchronous emergency "hard stop" signal if the evaluation exceeds strictly allowed time?
-   - **Options**:
+    - **Options**:
       - A) Yes (Search loop checks `time.time()` every N iterations)
       - B) No (Rely on host OS/Container to kill the process)
-   - **Recommended**: Option A - Mandatory for a robust backend engine.
+    - **Recommended**: Option A - Mandatory for a robust backend engine.
 
 28. **Resumability**: Can an MCTS search tree state be paused and safely resumed across multiple network requests?
-   - **Options**:
+    - **Options**:
       - A) Yes (Store the tree in a shared Redis/Cache)
       - B) No (Engine is stateless; a new request starts a new search)
-   - **Recommended**: Option B - Statelessness is simpler to scale horizontally.
+    - **Recommended**: Option B - Statelessness is simpler to scale horizontally.
 
 29. **Time Pools**: Will the engine support variable time pools per player (e.g., blitz vs standard time controls)?
-   - **Options**:
+    - **Options**:
       - A) Yes (Engine accepts a `time_budget_ms` parameter)
       - B) No (Global 5-second limit)
-   - **Recommended**: Option A - Allows the same engine to power both "Fast Preview" and "Deep Calculation" use cases.
+    - **Recommended**: Option A - Allows the same engine to power both "Fast Preview" and "Deep Calculation" use cases.
 
 30. **Early Termination**: What happens if the absolute depth limit of 3 is fully exhausted before the 5 seconds are up?
-   - **Options**:
+    - **Options**:
       - A) Return Result (Stop and save the computation cost)
       - B) Iterative Deepening (Proceed to Depth 4+ until time runs out)
-   - C) Statistical Softening (Use remaining time to run more rollouts on current leaves)
-   - **Recommended**: Option B - If time remains, deeper search is always better for accuracy.
+    - C) Statistical Softening (Use remaining time to run more rollouts on current leaves)
+    - **Recommended**: Option B - If time remains, deeper search is always better for accuracy.
 
 ## 7. Concurrency & Parallelization
 
 31. **Threading Model**: Does the search employ Root Parallelism, Leaf Parallelism, or Tree Parallelism?
-   - **Options**:
+    - **Options**:
       - A) Root Parallelism (Run N independent trees, merge results at end - easiest)
       - B) Tree Parallelism (Multiple threads share one tree - requires locking)
       - C) Leaf Parallelism (Search is serial, but terminal evaluations are parallel)
-   - **Recommended**: Option A - Root Parallelism is the most Python-friendly (avoiding GIL issues) and scales well in containerized environments.
+    - **Recommended**: Option A - Root Parallelism is the most Python-friendly (avoiding GIL issues) and scales well in containerized environments.
 
 32. **Mutex Locks**: If using Tree Parallelism, how are node statistic updates handle concurrency (lock-free vs mutexed)?
-   - **Options**:
+    - **Options**:
       - A) Lock-free (Atomic updates using specific CPU instructions - complex in Python)
       - B) Mutexed (Standard locks on node objects)
       - C) Batch Updates (Workers accumulate stats and update the tree in a single-threaded sweep)
-   - **Recommended**: Option C - Batching updates minimizes lock contention and provides cleaner trace logs.
+    - **Recommended**: Option C - Batching updates minimizes lock contention and provides cleaner trace logs.
 
 33. **Instance Scaling**: What is the maximum target thread count per container instance?
-   - **Options**:
+    - **Options**:
       - A) Single-threaded (1 vCPU)
       - B) 4-8 Threads (Standard high-performance container)
       - C) Elastic (Scale based on available machine cores)
-   - **Recommended**: Option B - Standardizing on 4-8 threads provides predictable performance for 5-second budgets.
+    - **Recommended**: Option B - Standardizing on 4-8 threads provides predictable performance for 5-second budgets.
 
 34. **Cache Syncing**: How are transposition tables synchronized across multiple worker threads efficiently?
-   - **Options**:
+    - **Options**:
       - A) Shared Memory Hash Table (requires extreme care with Python objects)
       - B) Per-Thread Cache (No sync, higher memory usage)
       - C) Sharded Cache (Divide hash range across workers)
-   - **Recommended**: Option C - Sharding reduces collisions and works well with root parallelism.
+    - **Recommended**: Option C - Sharding reduces collisions and works well with root parallelism.
 
 35. **Determinism vs Speed**: Will thread races be permitted if it increases nodes-per-second, or is strict determinism required?
-   - **Options**:
+    - **Options**:
       - A) Strict Determinism (Repeatable results for debugging/testing)
       - B) Asynchronous Racy Updates (Accept small inaccuracies for higher throughput)
-   - **Recommended**: Option A - Determinism is a strict requirement for `vindicta-platform` to ensure audit trails and repeatable tests.
+    - **Recommended**: Option A - Determinism is a strict requirement for `vindicta-platform` to ensure audit trails and repeatable tests.
 
 ## 8. Pruning & Tree Reduction
 
 36. **Forward Pruning**: Is Forward Pruning aggressively applied to moves with historically low immediate payouts?
-   - **Options**:
+    - **Options**:
       - A) Yes (Only consider Top N most promising moves)
       - B) No (Trust UCT to naturally ignore bad branches)
-   - **Recommended**: Option A - aggressive pruning is necessary for 40k due to the high branching factor (e.g. dozens of targets for one unit).
+    - **Recommended**: Option A - aggressive pruning is necessary for 40k due to the high branching factor (e.g. dozens of targets for one unit).
 
 37. **Alpha-Beta Hybrid**: How exactly are Alpha-Beta pruning bounds integrated within an MCTS framework?
-   - **Options**:
+    - **Options**:
       - A) Fixed Bounds (Prune nodes below a hard static score)
       - B) Dynamic Windowing (Use MCTS visit counts to define search "windows")
       - C) No Hybrid (Use pure MCTS)
-   - **Recommended**: Option C - Stick to pure MCTS initially; alpha-beta hybrids are mathematically complex to integrate with UCT.
+    - **Recommended**: Option C - Stick to pure MCTS initially; alpha-beta hybrids are mathematically complex to integrate with UCT.
 
 38. **Symmetry**: Does the engine detect and eliminate obviously symmetrical board state permutations?
-   - **Options**:
+    - **Options**:
       - A) Automatic (Hash units by relative position rather than absolute ID)
       - B) Manual (Rules engine flags redundant moves)
       - C) Disabled (Accept the overhead)
-   - **Recommended**: Option C - Determining symmetry in a complex 3D 40k environment is often more expensive than just searching the Redundant node.
+    - **Recommended**: Option C - Determining symmetry in a complex 3D 40k environment is often more expensive than just searching the Redundant node.
 
 39. **Null Moves**: Are "Null Move" heuristics allowed to test for immediate localized threat detection?
-   - **Options**:
+    - **Options**:
       - A) Yes (Test if not moving still results in unit death)
       - B) No (Every unit must declare an action)
-   - **Recommended**: Option A - "What if I do nothing?" is a powerful baseline for evaluating threat levels.
+    - **Recommended**: Option A - "What if I do nothing?" is a powerful baseline for evaluating threat levels.
 
 40. **Dice Pruning**: How aggressive is the pruning on highly improbable dice combinations (e.g., failing five 2+ armor saves)?
-   - **Options**:
+    - **Options**:
       - A) Aggressive (Ignore roll outcomes with <1% probability)
       - B) Balanced (Ignore <0.1% probability)
       - C) Full (Include every possible discrete die combination)
-   - **Recommended**: Option A - Pruning extreme outliers keeps the tree representation sane and focused on realistic outcomes.
+    - **Recommended**: Option A - Pruning extreme outliers keeps the tree representation sane and focused on realistic outcomes.
 
 ## 9. Observability, Tracing, and Logging
 
 41. **Trace Format**: What industry-standard format is used for exported traces (OpenTelemetry, JSON logs)?
-   - **Options**:
+    - **Options**:
       - A) OpenTelemetry (OTLP) (Native support for Jaeger/Grafana)
       - B) Structured JSON Logs (Easy to pipe to ELK/CloudWatch)
       - C) Custom Binary (Fastest export, requires custom viewer)
-   - **Recommended**: Option A - Standardizing on OTel is mandatory for the `vindicta-foundation` observability goals.
+    - **Recommended**: Option A - Standardizing on OTel is mandatory for the `vindicta-foundation` observability goals.
 
 42. **PV Export**: Is the Final Principal Variation exported automatically to standard out or dedicated metrics stores?
-   - **Options**:
+    - **Options**:
       - A) Stdout (Simple for local dev)
       - B) Metric Store (Prometheus/InfluxDB)
       - C) API Payload (Returned in the search result object)
-   - **Recommended**: Option C - The PV is functional data; it belongs in the response payload.
+    - **Recommended**: Option C - The PV is functional data; it belongs in the response payload.
 
 43. **NPS Tracking**: How are nodes-per-second (NPS) and cache-hit metrics aggregated and visualized?
-   - **Options**:
+    - **Options**:
       - A) Prometheus Counters (Real-time monitoring)
       - B) Trace Attributes (Per-request granularity)
       - C) Console Logs (Debugging only)
-   - **Recommended**: Option B - Attaching NPS to the request trace identifies slow scenarios/board states.
+    - **Recommended**: Option B - Attaching NPS to the request trace identifies slow scenarios/board states.
 
 44. **Reproducibility**: Can developers trace and extract the exact random seed used for a specific outlier rollout?
-   - **Options**:
+    - **Options**:
       - A) Yes (Random seed is logged per request)
       - B) No (Seeds are transient)
-   - **Recommended**: Option A - Essential for fixing "hallucination" bugs where the AI makes a bizarre move.
+    - **Recommended**: Option A - Essential for fixing "hallucination" bugs where the AI makes a bizarre move.
 
 45. **Artifact Retention**: How long are full memory tree dumps (if Level 4 Trace is enabled) retained on disk?
-   - **Options**:
+    - **Options**:
       - A) 1 Hour (Local buffer)
       - B) 7 Days (Standard debug window)
       - C) Not Retained (Live stream only)
-   - **Recommended**: Option B - Seven days allows for retroactive post-mortem analysis of failed game sessions.
+    - **Recommended**: Option B - Seven days allows for retroactive post-mortem analysis of failed game sessions.
 
 ## 10. Hardware & Resource Limits
 
 46. **Hardware Acceleration**: Are neural network evaluations (if added later) explicitly targeted for CPU or GPU hardware?
-   - **Options**:
+    - **Options**:
       - A) CPU Only (Focus on vectorized AVX/SIMD instructions)
       - B) GPU Accelerated (Requires CUDA/ROCm dependencies)
       - C) NPU/Dedicated (Targeting edge AI hardware)
-   - **Recommended**: Option A - CPU-only simplifies the container deployment and is sufficient for the foundation's mathematical complexity.
+    - **Recommended**: Option A - CPU-only simplifies the container deployment and is sufficient for the foundation's mathematical complexity.
 
 47. **Memory Limits**: What is the default hard RAM limit for the Engine container (e.g., 1GB, 4GB)?
-   - **Options**:
+    - **Options**:
       - A) 1GB (Lightweight, high density)
       - B) 4GB (Balanced for large MCTS trees)
       - C) 16GB+ (For professional tournament-grade depth)
-   - **Recommended**: Option B - 4GB provides enough space for a massive transposition table and arena allocator.
+    - **Recommended**: Option B - 4GB provides enough space for a massive transposition table and arena allocator.
 
 48. **Eviction Strategy**: How is cache eviction managed when memory constraints are reached (LRU vs Depth-based)?
-   - **Options**:
+    - **Options**:
       - A) LRU (Least Recently Used - standard)
       - B) Depth-based (Protect nodes closer to the root)
       - C) Visit-based (Keep nodes with the most statistical weight)
-   - **Recommended**: Option C - In MCTS, the nodes with the most visits are the most valuable to retain.
+    - **Recommended**: Option C - In MCTS, the nodes with the most visits are the most valuable to retain.
 
 49. **Vectorization**: Does the engine rely on strict SIMD/Vectorization instruction sets for bit computations?
-   - **Options**:
+    - **Options**:
       - A) Explicit (Use NumPy/PyTorch internals for vector math)
       - B) Auto-vectorized (Trust Python interpreter/compiler)
       - C) None (Pure Python objects)
-   - **Recommended**: Option A - Mandatory for meeting the 5-second depth 3 goal in Python.
+    - **Recommended**: Option A - Mandatory for meeting the 5-second depth 3 goal in Python.
 
 50. **CPU Arch**: Will the infrastructure predominantly deploy on ARM64 (AWS Graviton/M-series) or standard x86_64?
-   - **Options**:
+    - **Options**:
       - A) ARM64 (Cost effective, modern)
       - B) x86_64 (Broad compatibility)
       - C) Multi-arch (Support both)
-   - **Recommended**: Option C - The codebase should be multi-arch, but ARM64 is the preferred production target for cost.
+    - **Recommended**: Option C - The codebase should be multi-arch, but ARM64 is the preferred production target for cost.
 
 ## 11. Integration with `vindicta-engine` (Core Logic)
 
 51. **Logic Duplication**: Does MCTS duplicate `vindicta-engine`'s rules internally for speed, or call the module directly?
-   - **Options**:
+    - **Options**:
       - A) Call Directly (Maintainable, slower)
       - B) Compiled Subset (Duplicate critical path logic in Cython/Numba for speed)
       - C) Logic Mapping (MCTS uses a simplified proxy of the full engine)
-   - **Recommended**: Option B - Re-implementing the core "Move/Hit/Wound" loop in a high-performance subset is essential for Stockfish-level speed.
+    - **Recommended**: Option B - Re-implementing the core "Move/Hit/Wound" loop in a high-performance subset is essential for Stockfish-level speed.
 
 52. **State Mutability**: Is `vindicta-engine` structurally stateless enough to support concurrent node expansion without cloning entire domains?
-   - **Options**:
+    - **Options**:
       - A) Full Clone (Copy entire GameState object - slow)
       - B) Copy-on-Write (Only clone modified units)
       - C) Delta-based (Apply moves and then "Undo" them to return to parent state)
-   - **Recommended**: Option C - "Undo" logic (Rollback) is the preferred industry standard for high-performance search engines.
+    - **Recommended**: Option C - "Undo" logic (Rollback) is the preferred industry standard for high-performance search engines.
 
 53. **Rules Erratas**: How are mid-season rule erratas dynamically injected into the active search heuristics?
-   - **Options**:
+    - **Options**:
       - A) Factory Pattern (Inject new logic classes)
       - B) Parameterized Constants (Change math weights via config)
       - C) Code Deployment (Hard update the module)
-   - **Recommended**: Option B - Most erratas (e.g., points changes, AP caps) can be handled as weights in the evaluation function.
+    - **Recommended**: Option B - Most erratas (e.g., points changes, AP caps) can be handled as weights in the evaluation function.
 
 54. **Panic Handling**: What happens to a tree branch if `vindicta-engine` unexpectedly panics or throws an exception during rollout?
-   - **Options**:
+    - **Options**:
       - A) Prune & Log (Discard the branch, mark moves as invalid)
       - B) Hard Fail (Kill the search session)
       - C) Retry (Re-initialize state and try same move again)
-   - **Recommended**: Option A - Robust systems should prune the segment and continue searching healthy branches.
+    - **Recommended**: Option A - Robust systems should prune the segment and continue searching healthy branches.
 
 55. **Versioning Cycle**: How tightly coupled is the MCTS release cycle to `vindicta-engine` version updates?
-   - **Options**:
+    - **Options**:
       - A) Locked (Must match major.minor version)
       - B) Decoupled (MCTS implements a standard interface)
-   - **Recommended**: Option A - MCTS logic is inextricably tied to the exact rules version and point values.
+    - **Recommended**: Option A - MCTS logic is inextricably tied to the exact rules version and point values.
 
 ## 12. Integration with `vindicta-oracle` (RAG / Rules)
 
 56. **Live Queries**: Can the MCTS proactively query the Oracle during evaluation for unknown edge case rulings?
-   - **Options**:
+    - **Options**:
       - A) Yes (Synchronous RAG during search - extremely slow)
       - B) No (Oracle is used only for pre-processing or post-search logging)
       - C) Pre-cached (Oracle pre-generates common ruling summaries into the engine)
-   - **Recommended**: Option C - Oracle should bake "Rule Interpretations" into the Engine's move generator at startup.
+    - **Recommended**: Option C - Oracle should bake "Rule Interpretations" into the Engine's move generator at startup.
 
 57. **Pre-Validation**: Does the Oracle pre-validate the root node board state before an expensive search is initialized?
-   - **Options**:
+    - **Options**:
       - A) Yes (Ensure the starting position is legal)
       - B) No (Search anyway; illegal states will naturally have low win % or errors)
-   - **Recommended**: Option A - Prevents "Garbage In, Garbage Out" scenarios.
+    - **Recommended**: Option A - Prevents "Garbage In, Garbage Out" scenarios.
 
 58. **Illegality Penalties**: If the Oracle flags a strategy sequence as "illegal", is the branch pruned or heavily mathematically penalized?
-   - **Options**:
+    - **Options**:
       - A) Pruned (Immediate removal)
       - B) Penalized (Give it a -10,000 score, but keep it in the tree for trace visibility)
-   - **Recommended**: Option B - Keeping the branch with a massive penalty allows developers to see *why* the AI "wanted" to cheat.
+    - **Recommended**: Option B - Keeping the branch with a massive penalty allows developers to see *why* the AI "wanted" to cheat.
 
 59. **Caching**: Are Oracle queries cached globally per engine instance or flushed after every search?
-   - **Options**:
+    - **Options**:
       - A) Persistent (Global cache across all matches)
       - B) Session-scoped (Flushed after turn ends)
       - C) None
-   - **Recommended**: Option A - Rules donor change; keep them cached for the life of the container.
+    - **Recommended**: Option A - Rules donor change; keep them cached for the life of the container.
 
 60. **Blame Attribution**: How does MCTS attribute a win/loss specifically to a complex Oracle rules interpretation in its logs?
-   - **Options**:
+    - **Options**:
       - A) Specific Trace Tags (e.g. `ruling_id: 1234`)
       - B) Custom Log Level (Oracle Impact Level)
       - C) Narrative summary
-   - **Recommended**: Option A - Allows automated analysis of which "Rules Interpretations" lead to the highest win rates.
+    - **Recommended**: Option A - Allows automated analysis of which "Rules Interpretations" lead to the highest win rates.
 
 ## 13. Integration with `Vindicta-Agents`
 
 61. **Personality Bias**: Do Agents pass "personality" parameter weights into the MCTS to bias certain playstyles (aggressive vs defensive)?
-   - **Options**:
+    - **Options**:
       - A) Yes (Heuristic weights are passed in the request header)
       - B) No (MCTS is always "Optimal"; Agents decide which optimal move to take)
       - C) Mixed (Base weights are fixed, but agents can suggest "Focus Units")
-   - **Recommended**: Option A - Different agent personalities (e.g. World Eaters vs Tau) require fundamentally different exploration biases to feel "correct".
+    - **Recommended**: Option A - Different agent personalities (e.g. World Eaters vs Tau) require fundamentally different exploration biases to feel "correct".
 
 62. **Polling Frequency**: How often are Agents expected or allowed to poll the Engine for move suggestions?
-   - **Options**:
+    - **Options**:
       - A) Once per turn (Full plan generation)
       - B) Once per phase (Movement, Shooting, etc.)
       - C) Reactive (Whenever the GameState changes)
-   - **Recommended**: Option B - Phase-level polling allows for adjustments based on actual dice results without overwhelming the engine.
+    - **Recommended**: Option B - Phase-level polling allows for adjustments based on actual dice results without overwhelming the engine.
 
 63. **Partial Trees**: Can Agents request partial tree subsets (e.g., "what if I only move unit X") rather than the global best move?
-   - **Options**:
+    - **Options**:
       - A) Yes (Request scoped to specific unit IDs)
       - B) No (Search is always holistic)
-   - **Recommended**: Option A - Unit-scoped search is much faster for "Quick Look" scenarios.
+    - **Recommended**: Option A - Unit-scoped search is much faster for "Quick Look" scenarios.
 
 64. **Payload Syntax**: Do Agents send raw text via `warscribe-system` to the engine, or parsed JSON structures directly?
-   - **Options**:
+    - **Options**:
       - A) Raw Text (Engine handles parsing - high error risk)
       - B) Parsed JSON (Agents must use `warscribe-parser` first)
-   - **Recommended**: Option B - MCTS should only receive clean, mathematical JSON state.
+    - **Recommended**: Option B - MCTS should only receive clean, mathematical JSON state.
 
 65. **Interrupts**: How are real-time Agent interruptions (e.g., an opponent suddenly plays a stratagem) injected to halt the search?
-   - **Options**:
+    - **Options**:
       - A) Signal-based (SIGINT to the process)
       - B) Polling (Engine checks a "Halt" flag in a shared cache)
       - C) Connection Drop (Closing the socket kills the search)
-   - **Recommended**: Option C - Standard socket-level interruption is the cleanest for microservice architectures.
+    - **Recommended**: Option C - Standard socket-level interruption is the cleanest for microservice architectures.
 
 ## 14. Integration with `vindicta-economy`
 
 66. **Compute Bounding**: Is the total MCTS search depth bounded dynamically by a user's Gas Tank / token balance?
-   - **Options**:
+    - **Options**:
       - A) Yes (Depth is capped based on prepaid tokens)
       - B) No (Search completes, and user is billed after)
-   - **Recommended**: Option A - Preventing "Bill Shock" by capping compute at the request level is safer for the platform.
+    - **Recommended**: Option A - Preventing "Bill Shock" by capping compute at the request level is safer for the platform.
 
 67. **Cost Metric**: How are compute costs calculated and billed (seconds of CPU time vs total nodes searched)?
-   - **Options**:
+    - **Options**:
       - A) CPU Time (Ms used)
       - B) Node Count (Total unique states visited)
       - C) Tiered (Fixed price for Depth 2, Depth 3, etc.)
-   - **Recommended**: Option B - Node count is the most hardware-agnostic metric for fair billing.
+    - **Recommended**: Option B - Node count is the most hardware-agnostic metric for fair billing.
 
 68. **Depth Premiums**: Does requesting a deeper search (e.g., Depth 5) automatically deduct more economy tokens?
-   - **Options**:
+    - **Options**:
       - A) Linear (Price = Depth * X)
       - B) Exponential (Price = BranchingFactor ^ Depth)
       - C) Fixed
-   - **Recommended**: Option B - Computational cost for MCTS is exponential; the price should reflect that reality.
+    - **Recommended**: Option B - Computational cost for MCTS is exponential; the price should reflect that reality.
 
 69. **Mid-Search Exhaustion**: What is the behavior if an account runs out of tokens while a search is actively processing at Depth 2?
-   - **Options**:
+    - **Options**:
       - A) Immediate Kill (Discard all results)
       - B) Graceful Return (Return the best found results so far, bill the partial amount)
-   - **Recommended**: Option B - Users should still get what they paid for up to the point of exhaustion.
+    - **Recommended**: Option B - Users should still get what they paid for up to the point of exhaustion.
 
 70. **Free Tiers**: Are cached Principal Variations or shallow Depth 1 estimations provided at zero token cost?
-   - **Options**:
+    - **Options**:
       - A) Yes (Encourage use for basic validation)
       - B) No (All compute is metered)
-   - **Recommended**: Option A - Providing shallow "Sanity Checks" for free improves the ecosystem's developer experience.
+    - **Recommended**: Option A - Providing shallow "Sanity Checks" for free improves the ecosystem's developer experience.
 
 ## 15. Integration with `warscribe-system`
 
 71. **Output Notation**: Is the resulting Principal Variation (best line of play) automatically translated back into standard Warscribe notation?
-   - **Options**:
+    - **Options**:
       - A) Yes (Engine includes a `notation` field in response)
       - B) No (A separate `warscribe-encoder` service handles translation)
-   - **Recommended**: Option B - Keep the Engine purely mathematical; offload NLP/Notation logic to specialized services.
+    - **Recommended**: Option B - Keep the Engine purely mathematical; offload NLP/Notation logic to specialized services.
 
 72. **Input Parsing**: Are incoming GameStates natively parsed from Warscribe text logs before initializing the root node?
-   - **Options**:
+    - **Options**:
       - A) Yes (Support text-to-search)
       - B) No (Require pre-parsed state)
-   - **Recommended**: Option B - Explicit separation of concerns.
+    - **Recommended**: Option B - Explicit separation of concerns.
 
 73. **Ambiguity Handling**: How are ambiguous Warscribe commands (e.g., "move forward") deterministically mapped to specific MCTS coordinates?
-   - **Options**:
+    - **Options**:
       - A) Closest Legal (Engine guesses based on rules)
       - B) Error Out (Require exact coordinates)
       - C) Multi-branch (MCTS searches all possible interpretations of the ambiguity)
-   - **Recommended**: Option C - If a command is vague, the MCTS should search the top 3-5 interpretations and see which is strongest.
+    - **Recommended**: Option C - If a command is vague, the MCTS should search the top 3-5 interpretations and see which is strongest.
 
 74. **Narrative Export**: Does the MCTS output support including generated narrative explanations attached to the Warscribe output?
-   - **Options**:
+    - **Options**:
       - A) Yes (e.g. "AI chose this to block the charge lane")
       - B) No (Mathematical scores only)
-   - **Recommended**: Option B - MCTS handles "Why mathematically"; a separate LLM layer should handle "Why narratively".
+    - **Recommended**: Option B - MCTS handles "Why mathematically"; a separate LLM layer should handle "Why narratively".
 
 75. **Nested Sequences**: How are complex nested sequences (like a prolonged fight phase) represented in Warscribe coming from flattened MCTS branches?
-   - **Options**:
+    - **Options**:
       - A) Sequence IDs (Group nodes by Battle Round/Phase/Interaction)
-   - **Recommended**: Option A - Structured sequence IDs are necessary for multi-phase verification.
+    - **Recommended**: Option A - Structured sequence IDs are necessary for multi-phase verification.
 
 ## 16. Integration with `vindicta-platform` (Backend API)
 
 76. **Microservice Topology**: Does the Engine run as an isolated pod communicating via gRPC, or an embedded library?
-   - **Options**:
+    - **Options**:
       - A) Isolated Pod (gRPC/Protobuf)
       - B) Embedded Library (Imported directly into the Gateway)
       - C) Sidecar (Runs alongside the Game Manager)
-   - **Recommended**: Option A - Isolation allows scaling the compute-heavy Engine independently from the I/O-heavy Gateway.
+    - **Recommended**: Option A - Isolation allows scaling the compute-heavy Engine independently from the I/O-heavy Gateway.
 
 77. **Autoscaling Policy**: How are Engine instances autoscaled in Kubernetes (by message queue length, CPU utilization, or concurrent matches)?
-   - **Options**:
+    - **Options**:
       - A) Queue Length (NATS/RabbitMQ depth)
       - B) CPU Utilization (Standard HPA)
       - C) Custom (HPA based on "Active Search" count)
-   - **Recommended**: Option C - Since MCTS is a continuous "5-second burst", scaling based on the number of concurrently active searches prevents overloading nodes.
+    - **Recommended**: Option C - Since MCTS is a continuous "5-second burst", scaling based on the number of concurrently active searches prevents overloading nodes.
 
 78. **Session Pinning**: Are long-running game sessions pinned to specific Engine pods to maximize transposition table cache hits?
-   - **Options**:
+    - **Options**:
       - A) Yes (Sticky sessions via Ingress)
       - B) No (Any Engine can handle any request; cache is shared/external)
-   - **Recommended**: Option A - Transposition tables are too large to share efficiently; pinning dramatically increases performance.
+    - **Recommended**: Option A - Transposition tables are too large to share efficiently; pinning dramatically increases performance.
 
 79. **Client Disconnects**: How are network partitions or sudden client disconnects managed while an evaluation is running?
-   - **Options**:
+    - **Options**:
       - A) Terminate Search (Save compute)
       - B) Complete & Cache (Complete the search and store the result for 1 min)
-   - **Recommended**: Option B - If the client reconnects quickly, the result is immediately available.
+    - **Recommended**: Option B - If the client reconnects quickly, the result is immediately available.
 
 80. **Transport Protocol**: Is the main MCTS query API strictly synchronous REST, or asynchronously managed via WebHooks/WebSockets?
-   - **Options**:
+    - **Options**:
       - A) Synchronous (Request/Response)
       - B) Asynchronous (Submit Task -> Receive Callback/Webhook)
       - C) Streaming (WebSockets)
-   - **Recommended**: Option B - Mandatory for any task that takes >1 second to prevent gateway timeouts.
+    - **Recommended**: Option B - Mandatory for any task that takes >1 second to prevent gateway timeouts.
 
 ## 17. Simulation & Self-Play Infrastructure
 
 81. **Heuristic Tuning**: Does the ecosystem support the Engine playing against itself internally to automatically tune heuristics?
-   - **Options**:
+    - **Options**:
       - A) Yes (Continuous self-play loop)
       - B) No (Heuristics are tuned manually by rules experts)
-   - **Recommended**: Option A - Data-driven tuning is the only way to achieve "Stockfish" level accuracy.
+    - **Recommended**: Option A - Data-driven tuning is the only way to achieve "Stockfish" level accuracy.
 
 82. **Record Storage**: Where and how are self-play game records continuously archived for offline analysis?
-   - **Options**:
+    - **Options**:
       - A) Object Storage (S3/GCS as Parquet/Avro files)
       - B) SQL Database (Metadata only)
       - C) Search Tree Dumps
-   - **Recommended**: Option A - Parquet is ideal for training future neural network models.
+    - **Recommended**: Option A - Parquet is ideal for training future neural network models.
 
 83. **Elo Rating**: Is there a continuous integration step that gates deployment if the new Engine's Elo rating fails to beat the prior version?
-   - **Options**:
+    - **Options**:
       - A) Yes (CI runs N self-play matches before Merge)
       - B) No (Functional tests only)
-   - **Recommended**: Option A - Regression testing in game AI MUST include "Strength Verification".
+    - **Recommended**: Option A - Regression testing in game AI MUST include "Strength Verification".
 
 84. **Opening Books**: How are early-game "opening book" libraries generated and indexed from these self-play iterations?
-   - **Options**:
+    - **Options**:
       - A) Hash Map (Lookup by Board Hash)
       - B) SQL Index (Common turn 1 deployments)
-   - **Recommended**: Option A - Fast O(1) lookup for common turn 1 layouts.
+    - **Recommended**: Option A - Fast O(1) lookup for common turn 1 layouts.
 
 85. **Opponent Generation**: Does the Engine use specific adversarial matchmaking algorithms during self-play training?
-   - **Options**:
+    - **Options**:
       - A) Self (Newest vs Newest)
       - B) Ancestral (Newest vs Random prior versions)
       - C) Diversified (Aggressive Heuristic vs Defensive Heuristic)
-   - **Recommended**: Option B - Standard practice to prevent "strategy collapse" or overfitting.
+    - **Recommended**: Option B - Standard practice to prevent "strategy collapse" or overfitting.
 
 ## 18. Testing Strategy & Determinism
 
 86. **Strict Determinism**: Must the MCTS engine guarantee 100% deterministic output trees given a fixed integer seed?
-   - **Options**:
+    - **Options**:
       - A) Yes (Mandatory for regression testing)
       - B) No (Accept stochastic noise)
-   - **Recommended**: Option A - Non-deterministic AI is impossible to debug at scale.
+    - **Recommended**: Option A - Non-deterministic AI is impossible to debug at scale.
 
 87. **Mocking**: How do we mock the Entropy Buffer robustly for unit testing tree depth generation?
-   - **Options**:
+    - **Options**:
       - A) Fixed Returns (Roll 3 always returns 3)
       - B) Static Distributions (JSON files representing the curve)
       - C) Mathematical Proxy (Simple Gaussian function)
-   - **Recommended**: Option B - Using real data snapshots for mocks ensures the math logic handles "swingy" edge cases correctly.
+    - **Recommended**: Option B - Using real data snapshots for mocks ensures the math logic handles "swingy" edge cases correctly.
 
 88. **Regression Baselines**: Are there standardized regression scenario suites to ensure evaluation logic doesn't mathematically drift over time?
-   - **Options**:
+    - **Options**:
       - A) Yes (Suite of 100 "Puzzle" board states with expected scores)
       - B) No (Focus on unit test coverage)
-   - **Recommended**: Option A - "Chess Puzzles" for 40k are essential for verifying heuristic changes.
+    - **Recommended**: Option A - "Chess Puzzles" for 40k are essential for verifying heuristic changes.
 
 89. **Memory Profiling**: Which tools are mandated for testing memory leaks and fragmentation in the custom arena allocator?
-   - **Options**:
+    - **Options**:
       - A) Valgrind / Memcheck (Requires C-extensions)
       - B) `tracemalloc` / `objgraph` (Python-native)
       - C) Prometheus Memory Metrics
-   - **Recommended**: Option B - Standard for uv/Python 3.12 workspaces.
+    - **Recommended**: Option B - Standard for uv/Python 3.12 workspaces.
 
 90. **Coverage Gates**: What minimum percentage of BDD scenario coverage is expected strictly for MCTS extreme edge cases?
-   - **Options**:
+    - **Options**:
       - A) 90% (Project Standard)
       - B) 100% (Intent-to-Execution Mandate)
-   - **Recommended**: Option B - Essential for the core math modules as per `TDD_SKILL.md`.
+    - **Recommended**: Option B - Essential for the core math modules as per `TDD_SKILL.md`.
 
 ## 19. Security, Cheating, and Sandboxing
 
 91. **Payload Sanitization**: Could a maliciously crafted JSON GameState payload force the engine into an infinite parsing loop?
-   - **Options**:
+    - **Options**:
       - A) Yes (If recursive parser is used without depth limits)
       - B) No (JSON schemas and standard library parsers enforce strict limits)
-   - **Recommended**: Option B - Standardizing on `orjson` or `pydantic` with strict recursive depth guards is sufficient.
+    - **Recommended**: Option B - Standardizing on `orjson` or `pydantic` with strict recursive depth guards is sufficient.
 
 92. **Timeout Enforcement**: Are client connection timeouts and search time limits enforced strictly by the orchestrator or internally by the engine?
-   - **Options**:
+    - **Options**:
       - A) Internal (Engine monitors its own clock)
       - B) External (API Gateway kills the socket)
       - C) Dual (Both)
-   - **Recommended**: Option C - Redundant enforcement is required for high-availability systems.
+    - **Recommended**: Option C - Redundant enforcement is required for high-availability systems.
 
 93. **Hidden Objective Fishing**: Can malicious clients extract hidden opponent objectives by repeatedly probing the MCTS with targeted queries?
-   - **Options**:
+    - **Options**:
       - A) Yes (By observing score spikes for specific moves)
       - B) No (Search tree is scrubbed of all hidden state data before return)
-   - **Recommended**: Option B - "What the UI doesn't need, it shouldn't see."
+    - **Recommended**: Option B - "What the UI doesn't need, it shouldn't see."
 
 94. **Response Scrubbing**: Is the returned search tree sanitized to remove opponent-hidden states before dispatch to the client?
-   - **Options**:
+    - **Options**:
       - A) Yes (Sanitize `GameNode` metadata)
       - B) No (Metadata is already abstracted enough)
-   - **Recommended**: Option A - Mandatory for competitive integrity.
+    - **Recommended**: Option A - Mandatory for competitive integrity.
 
 95. **Rate Limiting**: At what gateway layer is MCTS evaluation request rate-limiting applied per user account?
-   - **Options**:
+    - **Options**:
       - A) NGINX / Network Ingress
       - B) Internal Engine Quota
       - C) Economy Layer (Gas Tank)
-   - **Recommended**: Option C - Tying compute strictly to the `Gas Tank` economy naturally limits abuse.
+    - **Recommended**: Option C - Tying compute strictly to the `Gas Tank` economy naturally limits abuse.
 
 ## 20. Frontend & `vindicta-platform.github.io`
 
 96. **Visual Overlays**: Does the single-page web frontend render MCTS evaluations visually (e.g., win probability bar graphs)?
-   - **Options**:
+    - **Options**:
       - A) Yes (Live-updating charts)
       - B) No (Text logs only)
-   - **Recommended**: Option A - Visualizing the "Swing" of a turn is a key feature of the platform.
+    - **Recommended**: Option A - Visualizing the "Swing" of a turn is a key feature of the platform.
 
 97. **Map Projections**: Are Principal Variations projected as movement arrows and pathing indicators on a 2D map in the browser?
-   - **Options**:
+    - **Options**:
       - A) Yes (SVG pathing overlays)
       - B) No (Coordinate lists only)
-   - **Recommended**: Option A - Visualizing "The AI's Intent" makes the platform significantly more usable for players.
+    - **Recommended**: Option A - Visualizing "The AI's Intent" makes the platform significantly more usable for players.
 
 98. **Fast What-Ifs**: Can the frontend request asynchronous "what-if" fast evaluations without committing to a turn?
-   - **Options**:
+    - **Options**:
       - A) Yes (Low-depth Depth 1 searches)
       - B) No (Only full turn evaluations allowed)
-   - **Recommended**: Option A - Allows players to "Check their Math" on move ideas.
+    - **Recommended**: Option A - Allows players to "Check their Math" on move ideas.
 
 99. **Loading States**: Flow-wise, how does the frontend UI gracefully handle the mandatory 5-second asynchronous loading states?
-   - **Options**:
+    - **Options**:
       - A) Skeleton Screens (Representing the board)
       - B) Progress Bar (Showing search depth progress)
       - C) Narrative Stream (Live log of what the AI is "thinking")
-   - **Recommended**: Option C - Streaming "Thinking..." logs is the most engaging way to handle high-latency AI tasks.
+    - **Recommended**: Option C - Streaming "Thinking..." logs is the most engaging way to handle high-latency AI tasks.
 
 100. **Client-Side Engine**: Are lightweight WASM (WebAssembly) versions of the MCTS engine planned for offloading compute to the browser?
-   - **Options**:
+    - **Options**:
        - A) Yes (Future Roadmap)
        - B) No (Keep compute behind the API for Prop/IP protection)
-   - **Recommended**: Option B - Competitive game logic should stay on the server to prevent cheating and reverse-engineering of the evaluation weights.
+    - **Recommended**: Option B - Competitive game logic should stay on the server to prevent cheating and reverse-engineering of the evaluation weights.

--- a/044-mcts-foundation/research.md
+++ b/044-mcts-foundation/research.md
@@ -1,4 +1,4 @@
-# Phase 0: Research & Architecture Decisions (FEAT-044)
+﻿# Phase 0: Research & Architecture Decisions (FEAT-044)
 
 ## 1. MCTS Arena Allocator in Python
 
@@ -18,7 +18,9 @@ SEARCH_NODE_DTYPE = np.dtype([
     ('is_terminal', np.bool_),
     ('depth', np.int8),
 ])
+
 # ~292 bytes per node
+
 ```
 
 **Arena Sizing**: Default 512MB buffer → ~1,750,000 nodes capacity. At 90% fill (1,575,000 nodes) the engine stops expanding and applies visit-based eviction (nodes with fewest visits are reclaimed first). At 100% capacity, the engine returns the best result found so far and sets `MCTSResult.arena_exhausted = True`.
@@ -30,6 +32,7 @@ SEARCH_NODE_DTYPE = np.dtype([
 **Note on COW vs Pool Coexistence**: Copy-on-write (COW) immutability (from data-model.md) applies to `GameState` objects — each tree expansion creates a new, immutable snapshot of the board. Arena pooling applies to `SearchNode` structural metadata (visit counts, child pointers, hashes). These are separate concerns: `GameState` is never mutated in-place, while `SearchNode` slots are reused from the pre-allocated pool. `SearchNode` fields like `visits` and `value_sum` are updated in-place during backpropagation since they are pool-managed structural counters, not domain state.
 
 **Alternatives considered**:
+
 - Native Python GC instantiation: Rejected due to OOM risk and GC jitter.
 - C++ Extension bindings: High maintenance overhead; deferred unless Python pooling fails performance targets.
 
@@ -125,11 +128,14 @@ class MCTSTracer:
 
 **Generation Strategy**:
 ```python
+
 # Generated once at module load, seeded deterministically for reproducibility
+
 ZOBRIST_SEED = 0xDEADBEEF_44000000  # Feature-specific seed
 rng = np.random.Generator(np.random.PCG64(ZOBRIST_SEED))
 
 # Constants for: unit_type × position_bucket × status_flag
+
 ZOBRIST_UNIT_TYPE = rng.integers(0, 2**64, size=(MAX_UNIT_TYPES,), dtype=np.uint64)
 ZOBRIST_POSITION = rng.integers(0, 2**64, size=(POSITION_BUCKETS,), dtype=np.uint64)
 ZOBRIST_STATUS = rng.integers(0, 2**64, size=(MAX_STATUS_FLAGS,), dtype=np.uint64)
@@ -223,23 +229,27 @@ class MockEntropyBuffer:
 **Context**: SC-001 requires Depth 3 in 5 seconds. We need to quantify the Nodes-Per-Second (NPS) target.
 
 **Branching Factor Analysis** (40k with cluster-based movement + pruning):
+
 - Movement: ~8 meaningful positions per unit
 - Shooting: ~4 target priority options per unit
 - Charge: ~3 options (charge, don't, overwatch)
 - With progressive unpruning, effective branching factor: **~15-25 moves per node**
 
 **NPS Target**:
+
 - Worst case Depth 3 tree: 25^3 = 15,625 nodes
 - With pruning + transpositions: ~5,000-8,000 unique nodes
 - Required NPS: **≥2,000 nodes/second** (gives 10,000 nodes in 5s with safety margin)
 - Target NPS with NumPy vectorization: **5,000+ nodes/second**
 
 **Adaptive Time Budget**:
+
 - Reserve 250ms safety buffer (4,750ms effective search time)
 - Check `time.monotonic()` every 100 node expansions
 - If 90% of budget consumed: stop deepening, return best result at current depth
 
 **Hardware Baseline** ("standard hardware"):
+
 - **CPU**: 4-core x86_64 or ARM64, ≥2.5 GHz (e.g., AWS t3.medium / Graviton3 equivalent)
 - **RAM**: 4GB container limit
 - **No GPU**: CPU-only evaluation
@@ -249,11 +259,13 @@ class MockEntropyBuffer:
 **Context**: Multiple `evaluate_state` calls may arrive simultaneously. Root Parallelism requires clear thread-safety boundaries.
 
 **Decision**:
+
 - Each `MCTSEngine` instance owns **one arena buffer** and is **NOT thread-safe** internally.
 - Concurrency is handled at the **service layer**: each incoming request gets its own `MCTSEngine` instance (or is queued to a worker pool of pre-initialized engines).
 - Root Parallelism (4 threads) operates **within** a single `evaluate_state` call using `multiprocessing.Pool` (avoids GIL). Each worker gets a slice of the arena.
 
 **Determinism Guarantee**: Root Parallelism produces deterministic results by:
+
 1. Splitting the arena into N fixed slices (not random).
 2. Merging results by selecting the child with the highest visit count across all workers.
 3. Using the same RNG seed per worker (worker_seed = base_seed + worker_id).
@@ -289,6 +301,7 @@ class MockEntropyBuffer:
 **Context**: Maliciously crafted payloads must not crash or hang the engine.
 
 **Decision**:
+
 - **Max payload size**: 2MB for JSON (reject with HTTP 413 at gateway)
 - **Max nested depth**: 10 levels (enforced by `pydantic` model validators)
 - **Max units per state**: 200 (reject states with more)
@@ -334,6 +347,7 @@ class AttackProfile:
 **Context**: FR-007 requires architecture documentation in `docs/architecture/mcts_engine.md`.
 
 **Required Sections**:
+
 1. **Overview** — Purpose, position in the Vindicta ecosystem
 2. **Architecture Diagram** — C4 Component-level showing Engine ↔ Foundation ↔ Oracle
 3. **Arena Allocator Internals** — Memory layout, sizing, eviction strategy

--- a/044-mcts-foundation/research.md
+++ b/044-mcts-foundation/research.md
@@ -1,4 +1,4 @@
-﻿# Phase 0: Research & Architecture Decisions (FEAT-044)
+# Phase 0: Research & Architecture Decisions (FEAT-044)
 
 ## 1. MCTS Arena Allocator in Python
 
@@ -127,6 +127,7 @@ class MCTSTracer:
 **Decision**: Use Zobrist Hashing with pre-generated 64-bit random constants.
 
 **Generation Strategy**:
+
 ```python
 
 # Generated once at module load, seeded deterministically for reproducibility

--- a/044-mcts-foundation/tasks.md
+++ b/044-mcts-foundation/tasks.md
@@ -1,4 +1,4 @@
-# Tasks: FEAT-044 MCTS Engine Foundation (PAUSED)
+﻿# Tasks: FEAT-044 MCTS Engine Foundation (PAUSED)
 
 > [!IMPORTANT]
 > This task is currently **PAUSED** per ADL directive (2026-03-07) to prioritize the organization-wide CI template rollout.
@@ -196,19 +196,23 @@
 ### Parallel Opportunities
 
 #### Phase 1 (Setup)
+
 - T003, T004, T005 can all run in parallel (different files)
 
 #### Phase 2 (Foundational)
+
 - T006, T007, T008 can all run in parallel [P] (independent models, same file is safe since each is a separate class definition)
 - T012 can run in parallel with T010, T011 (different files)
 - T013, T014, T015, T016 can all run in parallel (different test files/sections)
 - T017a, T017b can run in parallel with other foundational tasks (FR-008 validation)
 
 #### Phase 3 (US1) & Phase 4 (US2) — can run in parallel
+
 - T018, T019, T019a, T020, T020a can run in parallel (different test focus areas)
 - T029, T030, T031, T032, T033, T034 can all run in parallel (all in test_generator.py but independent test cases)
 
 #### Phase 5 (Polish)
+
 - T042, T043, T044, T046, T047, T048b, T049 can all run in parallel
 
 ---
@@ -216,25 +220,33 @@
 ## Parallel Example: User Story 1
 
 ```bash
+
 # Launch all tests for User Story 1 together:
+
 Task T018: "Contract test for MCTSEngine.evaluate_state() in tests/mcts/test_engine.py"
 Task T019: "Unit test for static evaluation heuristic in tests/mcts/test_heuristics.py"
 Task T020: "Integration test for end-to-end evaluation in tests/mcts/test_engine.py"
 
 # Launch core implementation (after tests fail):
+
 Task T021: "Static evaluation heuristic in src/vindicta_engine/mcts/heuristics.py"
 Task T022: "Entropy Buffer integration stub in src/vindicta_engine/mcts/heuristics.py"
+
 # Then sequential:
+
 Task T023 → T024 → T025 → T026 → T027 → T028 (engine core loop, depends on heuristics)
 ```
 
 ## Parallel Example: User Story 2
 
 ```bash
+
 # Launch ALL tests for User Story 2 together:
+
 Task T029-T034: "All move generator tests in tests/mcts/test_generator.py"
 
 # Launch implementation (after tests fail):
+
 Task T035: "MoveGenerator class skeleton"
 Task T036-T040: "Phase-specific logic (can be partially parallel within generator.py)"
 Task T041: "Wire into engine (sequential, depends on T035 + US1 engine)"

--- a/045-positional-heuristics/checklists/requirements.md
+++ b/045-positional-heuristics/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 045-positional-heuristics
+﻿# Specification Quality Checklist: 045-positional-heuristics
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "geometric strategic value" outcomes.

--- a/046-roster-synergy/checklists/requirements.md
+++ b/046-roster-synergy/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 046-roster-synergy
+﻿# Specification Quality Checklist: 046-roster-synergy
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "cross-unit efficiency" outcomes.

--- a/047-upset-detector/checklists/requirements.md
+++ b/047-upset-detector/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: 047-upset-detector
+﻿# Specification Quality Checklist: 047-upset-detector
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-01
@@ -30,4 +30,5 @@
 - [x] No implementation details leak into specification
 
 ## Notes
+
 - Checked. Focused on "performance anomaly detection" outcomes.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,13 +1,15 @@
-# specs Development Guidelines
+﻿# specs Development Guidelines
 
 Auto-generated from feature specifications. Last updated: 2026-03-01
 
 ## Core Rules & Governance
 
 ### G-001: GitHub MCP Priority
+
 Agents MUST prioritize `github-mcp-server` for all GitHub interactions (Issues, PRs, metadata). Fallback to `gh` CLI ONLY if MCP is unavailable or lacks specific functionality. Local `git` commands remain valid for direct filesystem workspace synchronization.
 
 ### G-002: Spec-Driven Methodology (BDD-First)
+
 No code without a Spec. All development MUST follow the **BDD → TDD → Implementation** flow. Behavioral expectations MUST be defined and confirmed failing FIRST. The `.specify` folder is the single source of truth.
 
 ## Project Structure
@@ -21,16 +23,19 @@ No code without a Spec. All development MUST follow the **BDD → TDD → Implem
 ```
 
 ## Active Technologies
+
 - **MCP**: github-mcp-server (Primary for GitHub Ops)
 - **Environment**: Windows (PowerShell/Batch)
 - **Dependency Management**: uv
 - **Methodology**: BDD-First Spec-Driven Development
 
 ## Commands
+
 - `specify`: Feature orchestration and status
 - `just`: Ecosystem automation and setup
 
 ## Code Style
+
 - **Brevity**: Avoided in favor of technical nuance and thorough Chains of Thought.
 - **Async-First**: Mandatory `async/await` for I/O operations.
 - **EntropyProof**: Deterministic mechanical resolutions via CSPRNG.

--- a/trigger-spec-pipelines.ps1
+++ b/trigger-spec-pipelines.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = "Continue"
+
+# Find all directories that start with a number (e.g., 001-ocr-parser)
+$specDirs = Get-ChildItem -Directory -Filter "0*" | Select-Object -ExpandProperty Name
+
+foreach ($spec in $specDirs) {
+    if (Test-Path "$spec\spec.md") {
+        Write-Host "Triggering speckit-pipeline for $spec..."
+        gh workflow run speckit-pipeline.yml -f feature_dir="$spec"
+        # Small delay to prevent API rate limiting
+        Start-Sleep -Seconds 2
+    } else {
+        Write-Host "Skipping $spec (No spec.md found)."
+    }
+}
+
+Write-Host "All pipelines triggered."

--- a/trigger-spec-pipelines.ps1
+++ b/trigger-spec-pipelines.ps1
@@ -6,9 +6,9 @@ $specDirs = Get-ChildItem -Directory -Filter "0*" | Select-Object -ExpandPropert
 foreach ($spec in $specDirs) {
     if (Test-Path "$spec\spec.md") {
         Write-Host "Triggering speckit-pipeline for $spec..."
-        gh workflow run speckit-pipeline.yml -f feature_dir="$spec"
+        gh workflow run speckit-pipeline.yml --ref chore/pipeline-automation -f feature_dir="$spec"
         # Small delay to prevent API rate limiting
-        Start-Sleep -Seconds 2
+        Start-Sleep -Seconds 1
     } else {
         Write-Host "Skipping $spec (No spec.md found)."
     }


### PR DESCRIPTION
Removes the Clarify step from the speckit pipeline, as extended_clarifications.md is an anomaly. Adds a trigger script trigger-spec-pipelines.ps1 to execute the pipeline for all spec directories.