### PR TITLE
fix: improve spec-to-issue-sync reliability

### DIFF
--- a/.github/workflows/spec-to-issue-sync.yml
+++ b/.github/workflows/spec-to-issue-sync.yml
@@ -84,34 +84,28 @@ jobs:
             let created = 0;
             let skipped = 0;
 
-            // Track titles created in this run to prevent duplicates from
-            // indexing delay (issue #12 in workflow review)
-            const createdTitles = new Set();
-
-            for (const task of tasks) {
-              const issueTitle = `[${featureDir}] Task ${task.num}: ${task.title}`;
-
-              // Skip if we already created this title in this run
-              if (createdTitles.has(issueTitle)) {
-                core.info(`Skipping: ${issueTitle} (created earlier in this run)`);
-                skipped++;
-                continue;
-              }
-
-              // Check if issue already exists using List API (no indexing delay)
-              const { data: existingIssues } = await github.rest.issues.listForRepo({
+            // Fetch all existing speckit issues upfront (with pagination)
+            // to avoid repeated API calls inside the loop
+            const existingIssues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 state: 'all',
                 labels: 'speckit,automated',
                 per_page: 100
-              });
+              }
+            );
+            const existingTitles = new Set(existingIssues.map(i => i.title));
 
-              const alreadyExists = existingIssues.some(issue =>
-                issue.title === issueTitle
-              );
+            // Track titles created in this run to prevent duplicates
+            const createdTitles = new Set();
 
-              if (alreadyExists) {
+            for (const task of tasks) {
+              const issueTitle = `[${featureDir}] Task ${task.num}: ${task.title}`;
+
+              // Skip if already exists remotely or created earlier in this run
+              if (existingTitles.has(issueTitle) || createdTitles.has(issueTitle)) {
                 core.info(`Skipping: ${issueTitle} (already exists)`);
                 skipped++;
                 continue;
@@ -120,7 +114,7 @@ jobs:
               const issueBody = [
                 `## ${task.title}`,
                 '',
-                `**Source:** \`${featureDir}/tasks.md\` — Task ${task.num}`,
+                `**Source:** \`${featureDir}/tasks.md\` -- Task ${task.num}`,
                 '',
                 task.body,
                 '',
@@ -141,7 +135,7 @@ jobs:
               core.info(`Created: ${issueTitle}`);
             }
 
-            core.summary.addRaw(`## 📋 Spec-to-Issue Sync\n\n`);
+            core.summary.addRaw(`## Spec-to-Issue Sync\n\n`);
             core.summary.addRaw(`- **Feature:** \`${featureDir}\`\n`);
             core.summary.addRaw(`- **Created:** ${created} issues\n`);
             core.summary.addRaw(`- **Skipped:** ${skipped} (already exist)\n`);

--- a/.github/workflows/spec-to-issue-sync.yml
+++ b/.github/workflows/spec-to-issue-sync.yml
@@ -31,9 +31,11 @@ jobs:
 
       - name: Detect changed tasks
         id: detect
+        env:
+          FEATURE_INPUT: ${{ inputs.feature_dir }}
         run: |
-          if [ -n "${{ inputs.feature_dir }}" ]; then
-            FEATURE_DIR="${{ inputs.feature_dir }}"
+          if [ -n "$FEATURE_INPUT" ]; then
+            FEATURE_DIR="$FEATURE_INPUT"
           else
             FEATURE_DIR=$(git diff --name-only HEAD~1 HEAD | grep 'tasks.md' | head -1 | xargs dirname 2>/dev/null || echo "")
           fi
@@ -82,15 +84,34 @@ jobs:
             let created = 0;
             let skipped = 0;
 
+            // Track titles created in this run to prevent duplicates from
+            // indexing delay (issue #12 in workflow review)
+            const createdTitles = new Set();
+
             for (const task of tasks) {
               const issueTitle = `[${featureDir}] Task ${task.num}: ${task.title}`;
 
-              // Check if issue already exists
-              const { data: existing } = await github.rest.search.issuesAndPullRequests({
-                q: `repo:vindicta-platform/specs "${issueTitle}" is:issue`
+              // Skip if we already created this title in this run
+              if (createdTitles.has(issueTitle)) {
+                core.info(`Skipping: ${issueTitle} (created earlier in this run)`);
+                skipped++;
+                continue;
+              }
+
+              // Check if issue already exists using List API (no indexing delay)
+              const { data: existingIssues } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'all',
+                labels: 'speckit,automated',
+                per_page: 100
               });
 
-              if (existing.total_count > 0) {
+              const alreadyExists = existingIssues.some(issue =>
+                issue.title === issueTitle
+              );
+
+              if (alreadyExists) {
                 core.info(`Skipping: ${issueTitle} (already exists)`);
                 skipped++;
                 continue;
@@ -108,13 +129,14 @@ jobs:
               ].join('\n');
 
               await github.rest.issues.create({
-                owner: 'vindicta-platform',
-                repo: 'specs',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
                 title: issueTitle,
                 body: issueBody,
                 labels: ['speckit', 'automated']
               });
 
+              createdTitles.add(issueTitle);
               created++;
               core.info(`Created: ${issueTitle}`);
             }


### PR DESCRIPTION
## 🔧 Issue Sync Reliability

Fixes two problems in the Spec-to-Issue Sync workflow that could cause duplicates or break on forks.

### Issues Fixed

| # | Issue | Fix |
|---|---|---|
| 11 | Hardcoded `vindicta-platform` / `specs` in issue creation and search | Replaced with `context.repo.owner` / `context.repo.repo` |
| 12 | Search API dedup has indexing delay, causing duplicates during rapid creation | Replaced with `issues.listForRepo` (List API, no indexing delay) + in-run `Set` to track titles created within the same run |

### Key Changes
- `github.rest.search.issuesAndPullRequests` → `github.rest.issues.listForRepo` with label filter
- `owner: 'vindicta-platform'`, `repo: 'specs'` → `context.repo.owner`, `context.repo.repo`
- Added `createdTitles` Set to prevent same-run duplicates

### Review Checklist
- [x] No hardcoded org/repo references
- [x] Dedup uses instant List API instead of delayed Search API
- [x] Same-run duplicate prevention via in-memory Set